### PR TITLE
[#275] 판매내역 정산금, 상품 상세페이지 UI를 수정한다.

### DIFF
--- a/src/main/resources/templates/trendpick/admin/sales.html
+++ b/src/main/resources/templates/trendpick/admin/sales.html
@@ -8,7 +8,11 @@
 <main class="min-h-screen flex flex-col" layout:fragment="main">
     <br/><br/>
     <h1 class="text-center text-5xl font-bold mb-6">판매내역</h1>
-    <div><span th:text="${#dates.format(#dates.createNow(), 'MM')+'월 정산금: '+ #numbers.formatDecimal(totalPricePerMonth, 0, 'COMMA', 0, 'POINT')}+'원'"></span></div>
+
+    <div class="text-black p-2 rounded-lg font-bold text-right" style="font-size: 2em;">
+        <span th:text="${#dates.format(#dates.createNow(), 'MM')+'월 정산금: '+ #numbers.formatDecimal(totalPricePerMonth, 0, 'COMMA', 0, 'POINT')}+'원'"></span>
+    </div>
+
     <table class="table">
         <thead>
         <tr>
@@ -33,7 +37,7 @@
                     <div class="avatar">
                         <div class="mask mask-squircle w-12 h-12">
                             <a th:href="@{/trendpick/products/{productId}(productId=${order.productId})}">
-                                <img th:src="|https://kr.object.ncloudstorage.com/trendpick/${order.productFilePath}|" width="100" height="100"/>
+                                <img th:src="|/images/${order.productFilePath}|" width="100" height="100"/>
                             </a>
                         </div>
                     </div>

--- a/src/main/resources/templates/trendpick/products/detailpage.html
+++ b/src/main/resources/templates/trendpick/products/detailpage.html
@@ -261,6 +261,7 @@
             value++;
             document.getElementById('quantity').value = value;
             document.getElementById('buyQuantity').value = value; // This line was added
+            document.getElementById('addToCartQuantity').value = value; // This line was added
         }
 
         function decreaseValue() {
@@ -271,6 +272,7 @@
             }
             document.getElementById('quantity').value = value;
             document.getElementById('buyQuantity').value = value; // This line was added
+            document.getElementById('addToCartQuantity').value = value; // This line was added
         }
 
         function syncQuantities() {


### PR DESCRIPTION
# 개발 내용
- 판매내역의 정산금 div에 CSS를 적용
- 상품 상세페이지에 카트로 넘길시 quantity값이 연동안되는 문제를 해결