### PR TITLE
Feat/317 order item spring batch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,11 @@ dependencies {
 
     // ElasticSearch
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+
+    // batch
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
+    testImplementation 'org.springframework.batch:spring-batch-test'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/project/trendpick_pro/domain/common/base/rq/Rq.java
+++ b/src/main/java/project/trendpick_pro/domain/common/base/rq/Rq.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.context.annotation.RequestScope;
 import org.springframework.web.servlet.LocaleResolver;
 import project.trendpick_pro.domain.member.entity.Member;
@@ -82,6 +83,21 @@ public class Rq {
         // 기존 URL에 혹시 msg 파라미터가 있다면 그것을 지우고 새로 넣는다.
         return Ut.url.modifyQueryParam(url, "msg", msgWithTtl(msg));
     }
+
+    private String getCurrentUrl() {
+        String url = req.getRequestURI();
+        String queryStr = req.getQueryString();
+
+        if (StringUtils.hasText(queryStr)) {
+            url += "?" + queryStr;
+        }
+
+        return url;
+    }
+    public String modifyQueryParam(String paramName, String paramValue) {
+        return Ut.url.modifyQueryParam(getCurrentUrl(), paramName, paramValue);
+    }
+
     private String msgWithTtl(String msg) {
         return Ut.url.encode(msg) + ";ttl=" + new Date().getTime();
     }

--- a/src/main/java/project/trendpick_pro/domain/orders/entity/OrderItem.java
+++ b/src/main/java/project/trendpick_pro/domain/orders/entity/OrderItem.java
@@ -9,6 +9,8 @@ import project.trendpick_pro.domain.coupon.entity.CouponCard;
 import project.trendpick_pro.domain.orders.entity.dto.response.OrderItemDto;
 import project.trendpick_pro.domain.product.entity.product.Product;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Table(name = "order_item")
@@ -22,6 +24,8 @@ public class OrderItem {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_id")
     private Order order;
+
+    private LocalDateTime payDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
@@ -60,6 +64,7 @@ public class OrderItem {
         this.color = color;
         this.totalPrice = this.orderPrice * this.quantity;
         this.discountPrice = 0;
+        this.payDate=LocalDateTime.now();
 //        product.getProductOption().decreaseStock(quantity);
     }
 

--- a/src/main/java/project/trendpick_pro/domain/orders/repository/OrderItemRepository.java
+++ b/src/main/java/project/trendpick_pro/domain/orders/repository/OrderItemRepository.java
@@ -1,7 +1,15 @@
 package project.trendpick_pro.domain.orders.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import project.trendpick_pro.domain.orders.entity.OrderItem;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+   Page<OrderItem> findAllByPayDateBetween(LocalDateTime fromDate, LocalDateTime toDate, Pageable pageable);
+
+    List<OrderItem> findAllByPayDateBetween(LocalDateTime fromDate, LocalDateTime toDate);
 }

--- a/src/main/java/project/trendpick_pro/domain/orders/service/OrderService.java
+++ b/src/main/java/project/trendpick_pro/domain/orders/service/OrderService.java
@@ -19,6 +19,7 @@ import project.trendpick_pro.domain.orders.entity.dto.request.OrderSearchCond;
 import project.trendpick_pro.domain.orders.entity.dto.response.OrderDetailResponse;
 import project.trendpick_pro.domain.orders.entity.dto.response.OrderResponse;
 import project.trendpick_pro.domain.orders.exceoption.OrderNotFoundException;
+import project.trendpick_pro.domain.orders.repository.OrderItemRepository;
 import project.trendpick_pro.domain.orders.repository.OrderRepository;
 import project.trendpick_pro.domain.product.entity.product.Product;
 import project.trendpick_pro.domain.product.exception.ProductNotFoundException;
@@ -30,18 +31,21 @@ import project.trendpick_pro.global.rsData.RsData;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.time.LocalDateTime;
 
 @Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class OrderService {
+    private final OrderItemRepository orderItemRepository;
 
     private final OrderRepository orderRepository;
 
     private final CartService cartService;
     private final ProductService productService;
     private final FavoriteTagService favoriteTagService;
+
 
     @Transactional
     public RsData<Order> cartToOrder(Member member, List<Long> selectedItems) {
@@ -187,4 +191,8 @@ public class OrderService {
     public Page<OrderResponse> findCanceledOrders(Member member, int offset) {
         return orderRepository.findAllByMember(new OrderSearchCond(member.getId(), OrderStatus.CANCELED), PageRequest.of(offset, 10));
     }
+    public List<OrderItem> findAllByPayDateBetweenOrderByIdAsc(LocalDateTime fromDate, LocalDateTime toDate) {
+        return orderItemRepository.findAllByPayDateBetween(fromDate, toDate);
+    }
+
 }

--- a/src/main/java/project/trendpick_pro/domain/rebate/controller/AdmRebateController.java
+++ b/src/main/java/project/trendpick_pro/domain/rebate/controller/AdmRebateController.java
@@ -1,0 +1,95 @@
+package project.trendpick_pro.domain.rebate.controller;
+
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.StringUtils;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import project.trendpick_pro.domain.common.base.rq.Rq;
+import project.trendpick_pro.domain.member.entity.Member;
+import project.trendpick_pro.domain.rebate.entity.RebateOrderItem;
+import project.trendpick_pro.domain.rebate.service.RebateService;
+import project.trendpick_pro.global.rsData.RsData;
+import project.trendpick_pro.global.util.Ut;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Controller
+@RequestMapping("/trendpick/admin")
+@RequiredArgsConstructor
+@Slf4j
+public class AdmRebateController {
+        private final RebateService rebateService;
+        private final Rq rq;
+        @GetMapping("/makeData")
+        @PreAuthorize("hasAuthority({'BRAND_ADMIN'})")
+        public String showMakeData() {
+                return "trendpick/admin/makeData";
+        }
+
+        @PostMapping("/makeData")
+        @PreAuthorize("hasAuthority({'BRAND_ADMIN'})")
+        public String makeData(String yearMonth) {
+                String brandName=rq.getBrandName();
+                RsData makeDateRsData = rebateService.makeDate(brandName,yearMonth);
+                if(makeDateRsData.isFail()){
+                        return rq.historyBack("정산할 데이터가 없습니다.");
+                }
+                return rq.redirectWithMsg("/trendpick/admin/rebateOrderItemList?yearMonth=" + yearMonth, makeDateRsData);
+        }
+
+        @GetMapping("/rebateOrderItemList")
+        @PreAuthorize("hasAuthority({'BRAND_ADMIN'})")
+        public String showRebateOrderItemList(String yearMonth, Model model) {
+                if (!StringUtils.hasText(yearMonth)) {
+                        yearMonth = Ut.date.getCurrentYearMonth();
+                }
+                String brandName=rq.getBrandName();
+                List<RebateOrderItem> items = rebateService.findRebateOrderItemsByPayDateIn(brandName,yearMonth);
+
+                model.addAttribute("yearMonth", yearMonth);
+                model.addAttribute("items", items);
+
+                return "trendpick/admin/rebateOrderItemList";
+        }
+
+        @PostMapping("/rebateOne/{orderItemId}")
+        @PreAuthorize("hasAuthority({'BRAND_ADMIN'})")
+        public String rebateOne(@PathVariable long orderItemId, HttpServletRequest req) {
+                RsData rebateRsData = rebateService.rebate(orderItemId);
+
+                String referer = req.getHeader("Referer");
+                String yearMonth = Ut.url.getQueryParamValue(referer, "yearMonth", "");
+
+                return rq.redirectWithMsg("/trendpick/admin/rebateOrderItemList?yearMonth=" + yearMonth, rebateRsData);
+        }
+
+        @PostMapping("/rebate")
+        @PreAuthorize("hasAuthority({'BRAND_ADMIN'})")
+        public String rebate(String ids, HttpServletRequest req) {
+
+                String[] idsArr = ids.split(",");
+
+                Arrays.stream(idsArr)
+                        .mapToLong(Long::parseLong)
+                        .forEach(id -> {
+                                rebateService.rebate(id);
+                        });
+
+                String referer = req.getHeader("Referer");
+                String yearMonth = Ut.url.getQueryParamValue(referer, "yearMonth", "");
+
+                String redirect = "redirect:/trendpick/admin/rebateOrderItemList?yearMonth=" + yearMonth;
+                redirect += "&msg=" + Ut.url.encode("%d건의 정산품목을 정산처리하였습니다.".formatted(idsArr.length));
+
+                return redirect;
+        }
+}

--- a/src/main/java/project/trendpick_pro/domain/rebate/entity/RebateOrderItem.java
+++ b/src/main/java/project/trendpick_pro/domain/rebate/entity/RebateOrderItem.java
@@ -1,0 +1,156 @@
+package project.trendpick_pro.domain.rebate.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import project.trendpick_pro.domain.brand.entity.Brand;
+import project.trendpick_pro.domain.cart.entity.CartItem;
+import project.trendpick_pro.domain.coupon.entity.CouponCard;
+import project.trendpick_pro.domain.member.entity.Member;
+import project.trendpick_pro.domain.orders.entity.Order;
+import project.trendpick_pro.domain.orders.entity.OrderItem;
+import project.trendpick_pro.domain.orders.entity.dto.response.OrderItemDto;
+import project.trendpick_pro.domain.product.entity.product.Product;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@SuperBuilder
+@ToString(callSuper = true)
+public class RebateOrderItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "rebate_order_item_id")
+    private Long id;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "order_item_id")
+    private OrderItem orderItem;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "coupon_card_id")
+    private CouponCard couponCard;
+    @Column(name = "order_price", nullable = false)
+    private int orderPrice;
+
+    @Column(name = "total_price")
+    private int totalPrice;
+
+    @Column(name = "discount_price")
+    private int discountPrice;
+
+    @Column(name = "size", nullable = false)
+    private String size;
+
+    @Column(name = "color", nullable = false)
+    private String color;
+
+    @Column(name = "count", nullable = false)
+    private int quantity;
+
+    private LocalDateTime payDate; // 결제날짜
+    private LocalDateTime rebateDate;
+    // 상품
+    private String productSubject;
+
+    // 주문품목
+    private LocalDateTime orderItemCreateDate;
+
+    // 구매자 회원
+    @ManyToOne(fetch = LAZY)
+    @ToString.Exclude
+    @JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Member buyer;
+    private String buyerName;
+
+    // 판매자 회원
+    @ManyToOne(fetch = LAZY)
+    @ToString.Exclude
+    @JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Brand seller;
+    private String sellerName;
+
+    public RebateOrderItem(OrderItem orderItem) {
+        this.orderItem = orderItem;
+        order=orderItem.getOrder();
+        product=orderItem.getProduct();
+        couponCard=orderItem.getCouponCard();
+        orderPrice=orderItem.getOrderPrice();
+        totalPrice=orderItem.getTotalPrice();
+        discountPrice=orderItem.getDiscountPrice();
+        size=orderItem.getSize();
+        color=orderItem.getColor();
+        quantity=orderItem.getQuantity();
+        payDate=orderItem.getPayDate();
+        // 상품 추가 데이터
+        productSubject=orderItem.getProduct().getName();
+
+        // 주문 품목 추가데이터
+        orderItemCreateDate=orderItem.getOrder().getCreatedDate();
+
+        // 구매자 추가 데이터
+        buyer=orderItem.getOrder().getMember();
+        buyerName=orderItem.getOrder().getMember().getUsername();
+
+        // 판매자 추가 데이터
+        seller=orderItem.getProduct().getBrand();
+        sellerName=orderItem.getProduct().getBrand().getName();
+    }
+
+    public int calculateRebatePrice() {
+        return (totalPrice*quantity) - (int)(totalPrice * 0.05); // 정산금액 수수료 0.05% 제외하고 계산
+    }
+    public boolean isRebateAvailable() {
+        if (rebateDate != null) {
+            return false;
+        }
+        return true;
+    }
+
+    public void setRebateDone() {
+        rebateDate = LocalDateTime.now();
+    }
+
+    public boolean isRebateDone() {
+        return rebateDate != null;
+    }
+
+    public void updateWith(RebateOrderItem item){
+        orderItem = item.getOrderItem();
+        order=item.getOrder();
+        product=item.getProduct();
+        couponCard=item.getCouponCard();
+        orderPrice=item.getOrderPrice();
+        totalPrice=item.getTotalPrice();
+        discountPrice=item.getDiscountPrice();
+        size=item.getSize();
+        color=item.getColor();
+        quantity=item.getQuantity();
+        payDate=item.getPayDate();
+        productSubject=item.getProduct().getName();
+        orderItemCreateDate=item.getOrder().getCreatedDate();
+        buyer=item.getOrder().getMember();
+        buyerName=item.getOrder().getMember().getUsername();
+        seller=item.getProduct().getBrand();
+        sellerName=item.getProduct().getBrand().getName();
+    }
+}
+
+

--- a/src/main/java/project/trendpick_pro/domain/rebate/repository/RebateOrderItemRepository.java
+++ b/src/main/java/project/trendpick_pro/domain/rebate/repository/RebateOrderItemRepository.java
@@ -1,0 +1,17 @@
+package project.trendpick_pro.domain.rebate.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import project.trendpick_pro.domain.orders.entity.OrderItem;
+import project.trendpick_pro.domain.rebate.entity.RebateOrderItem;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface RebateOrderItemRepository extends JpaRepository<RebateOrderItem, Long> {
+    Optional<RebateOrderItem> findByOrderItemId(long orderItemId);
+
+  //  List<RebateOrderItem> findAllByPayDateBetweenOrderByIdAsc(LocalDateTime fromDate, LocalDateTime toDate);
+  List<RebateOrderItem> findAllByPayDateBetweenAndSellerNameOrderByIdAsc(LocalDateTime fromDate, LocalDateTime toDate, String sellerName);
+
+}

--- a/src/main/java/project/trendpick_pro/domain/rebate/service/RebateService.java
+++ b/src/main/java/project/trendpick_pro/domain/rebate/service/RebateService.java
@@ -1,0 +1,108 @@
+package project.trendpick_pro.domain.rebate.service;
+
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import project.trendpick_pro.domain.brand.entity.Brand;
+import project.trendpick_pro.domain.member.entity.Member;
+import project.trendpick_pro.domain.member.service.MemberService;
+import project.trendpick_pro.domain.orders.entity.Order;
+import project.trendpick_pro.domain.orders.entity.OrderItem;
+import project.trendpick_pro.domain.orders.service.OrderService;
+import project.trendpick_pro.domain.rebate.entity.RebateOrderItem;
+import project.trendpick_pro.domain.rebate.repository.RebateOrderItemRepository;
+import project.trendpick_pro.global.rsData.RsData;
+import project.trendpick_pro.global.util.Ut;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RebateService {
+    private final OrderService orderService;
+    private final MemberService memberService;
+    private final RebateOrderItemRepository rebateOrderItemRepository;
+
+    @Transactional
+    public RsData makeDate(String brandName,String yearMonth) {
+        int monthEndDay = Ut.date.getEndDayOf(yearMonth);
+
+        String fromDateStr = yearMonth + "-01 00:00:00.000000";
+        String toDateStr = yearMonth + "-%02d 23:59:59.999999".formatted(monthEndDay);
+        LocalDateTime fromDate = Ut.date.parse(fromDateStr);
+        LocalDateTime toDate = Ut.date.parse(toDateStr);
+
+        // 데이터 가져오기
+        List<OrderItem> orderItems = orderService.findAllByPayDateBetweenOrderByIdAsc(fromDate, toDate);
+
+        if(orderItems.isEmpty()){
+           return RsData.of("F-1","정산할 주문내역이 없습니다.");
+        }
+        List<OrderItem> brandOrderItems=new ArrayList<>();
+                for(OrderItem item: orderItems) {
+                    if (item.getProduct().getBrand().getName().equals(brandName)) {
+                        brandOrderItems.add(item);
+                    }
+                }
+
+        // 변환하기
+        List<RebateOrderItem> rebateOrderItems = brandOrderItems
+                .stream()
+                .map(this::toRebateOrderItem)
+                .toList();
+
+        // 저장하기
+        rebateOrderItems.forEach(item -> makeRebateOrderItem(brandName,item));
+        return RsData.of("S-1", "정산데이터가 성공적으로 생성되었습니다.");
+    }
+
+    @Transactional
+    public void makeRebateOrderItem(String brandName,RebateOrderItem item) {
+        RebateOrderItem oldRebateOrderItem = rebateOrderItemRepository.findByOrderItemId(item.getOrderItem().getId()).orElse(null);
+
+        if (oldRebateOrderItem != null) {
+            if (oldRebateOrderItem.isRebateDone()) {
+                return;
+            }
+
+            oldRebateOrderItem.updateWith(item);
+
+            rebateOrderItemRepository.save(oldRebateOrderItem);
+        } else {
+                rebateOrderItemRepository.save(item);
+        }
+    }
+
+    public RebateOrderItem toRebateOrderItem(OrderItem orderItem) {
+        return new RebateOrderItem(orderItem);
+    }
+
+    public List<RebateOrderItem> findRebateOrderItemsByPayDateIn(String brandName,String yearMonth) {
+        int monthEndDay = Ut.date.getEndDayOf(yearMonth);
+
+        String fromDateStr = yearMonth + "-01 00:00:00.000000";
+        String toDateStr = yearMonth + "-%02d 23:59:59.999999".formatted(monthEndDay);
+        LocalDateTime fromDate = Ut.date.parse(fromDateStr);
+        LocalDateTime toDate = Ut.date.parse(toDateStr);
+
+        return rebateOrderItemRepository.findAllByPayDateBetweenAndSellerNameOrderByIdAsc(fromDate, toDate,brandName);
+    }
+
+    @Transactional
+    public RsData rebate(long orderItemId) {
+        RebateOrderItem rebateOrderItem = rebateOrderItemRepository.findByOrderItemId(orderItemId).get();
+
+        if (rebateOrderItem.isRebateAvailable() == false) {
+            return RsData.of("F-1", "정산을 할 수 없는 상태입니다.");
+        }
+
+        rebateOrderItem.setRebateDone();
+        return RsData.of(
+                "S-1",
+                "주문품목번호 %d번에 대해서 정산을 완료하였습니다.".formatted(rebateOrderItem.getOrderItem().getId())
+        );
+    }
+}

--- a/src/main/java/project/trendpick_pro/global/job/JobConfig.java
+++ b/src/main/java/project/trendpick_pro/global/job/JobConfig.java
@@ -18,11 +18,11 @@ public class JobConfig {
     private final JobLauncher jobLauncher;
     private final Job makeRebateDataJob;
 
-    //@Scheduled(cron = "0 0 4 * * *") // 실제 코드
-     @Scheduled(cron = "30 * * * * *") // 개발용 코드
+    @Scheduled(cron = "0 0 4 * * *") // 실제 코드
+    // @Scheduled(cron = "30 * * * * *") // 개발용
     public void performMakeRebateDataJob() throws Exception {
-      //  String yearMonth = getPerformMakeRebateDataJobParam1Value(); // 실제 코드
-         String yearMonth = "2023-07"; // 개발용 코드
+        String yearMonth = getPerformMakeRebateDataJobParam1Value(); // 실제 코드
+      //   String yearMonth = "2023-07"; // 개발용
 
         JobParameters param = new JobParametersBuilder()
                 .addString("yearMonth", yearMonth)

--- a/src/main/java/project/trendpick_pro/global/job/JobConfig.java
+++ b/src/main/java/project/trendpick_pro/global/job/JobConfig.java
@@ -1,0 +1,40 @@
+package project.trendpick_pro.global.job;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class JobConfig {
+    private final JobLauncher jobLauncher;
+    private final Job makeRebateDataJob;
+
+    //@Scheduled(cron = "0 0 4 * * *") // 실제 코드
+     @Scheduled(cron = "30 * * * * *") // 개발용 코드
+    public void performMakeRebateDataJob() throws Exception {
+      //  String yearMonth = getPerformMakeRebateDataJobParam1Value(); // 실제 코드
+         String yearMonth = "2023-07"; // 개발용 코드
+
+        JobParameters param = new JobParametersBuilder()
+                .addString("yearMonth", yearMonth)
+                .toJobParameters();
+        JobExecution execution = jobLauncher.run(makeRebateDataJob, param);
+
+        System.out.println(execution.getStatus());
+    }
+
+    public String getPerformMakeRebateDataJobParam1Value() {
+        LocalDateTime rebateDate = LocalDateTime.now().getDayOfMonth() >= 15 ? LocalDateTime.now().minusMonths(1) : LocalDateTime.now().minusMonths(2);
+
+        return "%04d".formatted(rebateDate.getYear()) + "-" + "%02d".formatted(rebateDate.getMonthValue());
+    }
+}

--- a/src/main/java/project/trendpick_pro/global/job/makeRebateData/MakeRebateDataJobConfig.java
+++ b/src/main/java/project/trendpick_pro/global/job/makeRebateData/MakeRebateDataJobConfig.java
@@ -1,0 +1,105 @@
+package project.trendpick_pro.global.job.makeRebateData;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.data.RepositoryItemReader;
+import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Sort;
+import org.springframework.transaction.PlatformTransactionManager;
+import project.trendpick_pro.domain.orders.entity.OrderItem;
+import project.trendpick_pro.domain.orders.repository.OrderItemRepository;
+import project.trendpick_pro.domain.rebate.entity.RebateOrderItem;
+import project.trendpick_pro.domain.rebate.repository.RebateOrderItemRepository;
+import project.trendpick_pro.global.util.Ut;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class MakeRebateDataJobConfig {
+    private final OrderItemRepository orderItemRepository;
+    private final RebateOrderItemRepository rebateOrderItemRepository;
+    private final JobRepository jobRepository;
+
+    @Bean
+    public Job makeRebateDataJob(Step makeRebateDataStep1) {
+        return new JobBuilder("makeRebateDataJob", jobRepository)
+                .start(makeRebateDataStep1)
+                .build();
+    }
+
+    @Bean
+    @JobScope
+    public Step makeRebateDataStep1(
+            PlatformTransactionManager transactionManager,
+            ItemReader<OrderItem> orderItemReader,
+            ItemProcessor<OrderItem, RebateOrderItem> orderItemToRebateOrderItemProcessor,
+            ItemWriter<RebateOrderItem> rebateOrderItemWriter
+    ) {
+        return new StepBuilder("makeRebateDataStep1", jobRepository)
+                .<OrderItem, RebateOrderItem>chunk(100, transactionManager)
+                .reader(orderItemReader)
+                .processor(orderItemToRebateOrderItemProcessor)
+                .writer(rebateOrderItemWriter)
+                .build();
+    }
+
+    @StepScope
+    @Bean
+    public RepositoryItemReader<OrderItem> orderItemReader(
+            @Value("#{jobParameters['yearMonth']}") String yearMonth
+    ) {
+        int monthEndDay = Ut.date.getEndDayOf(yearMonth);
+        LocalDateTime fromDate = Ut.date.parse(yearMonth + "-01 00:00:00.000000");
+        LocalDateTime toDate = Ut.date.parse(yearMonth + "-%02d 23:59:59.999999".formatted(monthEndDay));
+
+        return new RepositoryItemReaderBuilder<OrderItem>()
+                .name("orderItemReader")
+                .repository(orderItemRepository)
+                .methodName("findAllByPayDateBetween")
+                .pageSize(100)
+                .arguments(Arrays.asList(fromDate, toDate))
+                .sorts(Collections.singletonMap("id", Sort.Direction.ASC))
+                .build();
+    }
+
+    @StepScope
+    @Bean
+    public ItemProcessor<OrderItem, RebateOrderItem> orderItemToRebateOrderItemProcessor() {
+        return RebateOrderItem::new;
+    }
+
+    @StepScope
+    @Bean
+    public ItemWriter<RebateOrderItem> rebateOrderItemWriter() {
+        return items -> items.forEach(item -> {
+            RebateOrderItem oldRebateOrderItem = rebateOrderItemRepository.findByOrderItemId(item.getOrderItem().getId()).orElse(null);
+
+            if (oldRebateOrderItem != null) {
+                if (oldRebateOrderItem.isRebateDone()) {
+                    return;
+                }
+
+                rebateOrderItemRepository.delete(oldRebateOrderItem);
+            }
+
+            rebateOrderItemRepository.save(item);
+        });
+    }
+}

--- a/src/main/java/project/trendpick_pro/global/util/Ut.java
+++ b/src/main/java/project/trendpick_pro/global/util/Ut.java
@@ -2,6 +2,7 @@ package project.trendpick_pro.global.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Component;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -10,12 +11,13 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Map;
+import java.util.*;
 
+@Component
 public class Ut {
     public static class json {
 
@@ -174,5 +176,77 @@ public class Ut {
 
             return url.substring(0, startPoint) + urlAfter;
         }
+        public static String getQueryParamValue(String url, String paramName, String defaultValue) {
+            String[] urlBits = url.split("\\?", 2);
+
+            if (urlBits.length == 1) {
+                return defaultValue;
+            }
+
+            urlBits = urlBits[1].split("&");
+
+            String param = Arrays.stream(urlBits)
+                    .filter(s -> s.startsWith(paramName + "="))
+                    .findAny()
+                    .orElse(paramName + "=" + defaultValue);
+
+            String value = param.split("=", 2)[1].trim();
+
+            return value.length() > 0 ? value : defaultValue;
+        }
     }
+    public static class date {
+        public static LocalDateTime bitsToLocalDateTime(List<Integer> bits) {
+            return LocalDateTime.of(bits.get(0), bits.get(1), bits.get(2), bits.get(3), bits.get(4), bits.get(5), bits.get(6));
+        }
+
+        public static int getEndDayOf(int year, int month) {
+            String yearMonth = year + "-" + "%02d".formatted(month);
+
+            return getEndDayOf(yearMonth);
+        }
+
+        public static int getEndDayOf(String yearMonth) {
+            LocalDate convertedDate = LocalDate.parse(yearMonth + "-01", DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+            convertedDate = convertedDate.withDayOfMonth(
+                    convertedDate.getMonth().length(convertedDate.isLeapYear()));
+
+            return convertedDate.getDayOfMonth();
+        }
+
+        public static LocalDateTime parse(String pattern, String dateText) {
+            return LocalDateTime.parse(dateText, DateTimeFormatter.ofPattern(pattern));
+        }
+
+        public static LocalDateTime parse(String dateText) {
+            return parse("yyyy-MM-dd HH:mm:ss.SSSSSS", dateText);
+        }
+
+        public static String getCurrentYearMonth() {
+            return LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM"));
+        }
+
+        public static <K, V> Map<K, V> mapOf(Object... args) {
+            Map<K, V> map = new LinkedHashMap<>();
+
+            int size = args.length / 2;
+
+            for (int i = 0; i < size; i++) {
+                int keyIndex = i * 2;
+                int valueIndex = keyIndex + 1;
+
+                K key = (K) args[keyIndex];
+                V value = (V) args[valueIndex];
+
+                map.put(key, value);
+            }
+
+            return map;
+        }
+
+        public static String nf(long number) {
+            return String.format("%,d", (int) number);
+        }
+    }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,13 @@ spring:
   profiles:
     active: dev
     include: secret, db, data, ela
+  batch:
+    job:
+      name: ${job.name:NONE}
+      enabled: false
+    jdbc:
+      initialize-schema: always
+
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher
@@ -10,6 +17,10 @@ spring:
         enabled: true
   jpa:
     defer-datasource-initialization: true
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100
   sql:
     init:
       mode: always

--- a/src/main/resources/templates/trendpick/admin/makeData.html
+++ b/src/main/resources/templates/trendpick/admin/makeData.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html layout:decorate="~{trendpick/usr/layout/layout.html}" xmlns:layout="http://www.w3.org/1999/xhtml">
+
+<head>
+    <title>정산데이터 생성</title>
+</head>
+
+<main layout:fragment="main">
+    <section class="section section-rebate-makeData flex-grow flex flex-col items-center justify-center">
+
+        <div class="max-w-md w-full px-2 pt-4">
+            <h1 class="font-bold text-lg">
+                <i class="fa-solid fa-code-merge"></i>
+
+                정산데이터 생성
+            </h1>
+
+            <form th:action method="POST" class="flex flex-col gap-3">
+                <div class="form-control">
+                    <label class="label">
+                        <span class="label-text">정산범위</span>
+                    </label>
+                    <select name="yearMonth" class="select select-bordered">
+                        <option value="2023-06">2023-06</option>
+                        <option value="2023-07">2023-07</option>
+                        <option value="2023-08">2023-08</option>
+                        <option value="2023-09">2023-09</option>
+                        <option value="2023-10">2023-10</option>
+                        <option value="2023-11">2023-11</option>
+                        <option value="2023-12">2023-12</option>
+                    </select>
+                </div>
+
+                <div class="grid grid-cols-2 mt-2 gap-2">
+                    <a th:href="@{/trendpick/admin/rebateOrderItemList}" class="btn btn-outline">생성된 정산 데이터 보기</a>
+                    <input class="btn btn-outline" type="submit" value="정산 데이터 생성">
+                </div>
+
+            </form>
+        </div>
+    </section>
+</main>
+
+</html>

--- a/src/main/resources/templates/trendpick/admin/rebateOrderItemList.html
+++ b/src/main/resources/templates/trendpick/admin/rebateOrderItemList.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html layout:decorate="~{trendpick/usr/layout/layout.html}" xmlns:layout="http://www.w3.org/1999/xhtml">
+
+<head>
+    <title>정산데이터 목록</title>
+</head>
+
+<main layout:fragment="main">
+    <section class="section container mx-auto">
+
+        <div class="px-2 pt-4">
+            <h1 class="font-bold text-lg">
+                <i class="fa-solid fa-sack-dollar"></i>
+                정산
+            </h1>
+
+            <div class="mt-2">
+                <select name="yearMonth" class="select select-bordered"
+                        th:currentUrl="${@rq.modifyQueryParam('yearMonth', '')}"
+                        onchange="location.href = this.getAttribute('currentUrl') + this.value;">
+                    <option value="2023-06">2023-06</option>
+                    <option value="2023-07">2023-07</option>
+                    <option value="2023-08">2023-08</option>
+                    <option value="2023-09">2023-09</option>
+                    <option value="2023-10">2023-10</option>
+                    <option value="2023-11">2023-11</option>
+                    <option value="2023-12">2023-12</option>
+                </select>
+                <script th:inline="javascript">
+                    const yearMonth = /*[[ ${yearMonth} ]]*/ null;
+                    $('select[name=yearMonth]').last().val(yearMonth);
+                </script>
+            </div>
+
+            <div class="overflow-x-auto mt-2">
+
+                <table class="table table-compact w-full">
+                    <thead>
+                    <tr>
+                        <th>
+                            <input type="checkbox" class="orderItemCheckboxAll checkbox">
+                        </th>
+                        <th>주문품목번호</th>
+                        <th>결제날짜</th>
+                        <th>상품명</th>
+                        <th>결제가격</th>
+                        <th>판매자</th>
+                        <th>정산금액</th>
+                        <th>정산날짜</th>
+                        <th>정산</th>
+                    </tr>
+                    </thead>
+
+                    <tbody>
+                    <tr th:each="item : ${items}">
+                        <td>
+                            <input onchange="OrderItemCheckbox__changed();" th:if="${item.rebateAvailable}"
+                                   type="checkbox" class="orderItemCheckbox checkbox" th:value="${item.orderItem.id}">
+                        </td>
+                        <td th:text="${item.orderItem.id}"></td>
+                        <td th:text="${#temporals.format(item.payDate, 'yy-MM-dd HH:mm')}"></td>
+                        <td th:text="${item.productSubject}"></td>
+                        <td th:text="${#numbers.formatDecimal(item.orderPrice, 0, 'COMMA', 0, 'POINT')} + ' 원 '"></td>
+                        <td th:text="${item.sellerName}"></td>
+                        <td th:text="${#numbers.formatDecimal(item.calculateRebatePrice(), 0, 'COMMA', 0, 'POINT')} + ' 원 '"></td>
+                        <td th:text="${#temporals.format(item.rebateDate, 'yy-MM-dd HH:mm')}"></td>
+                        <td>
+                            <a th:if="${item.rebateAvailable}" href="javascript:;" onclick="$(this).next().submit();"
+                               class="btn btn-primary btn-xs">정산</a>
+                            <form method="POST" th:action="@{|/trendpick/admin/rebateOne/${item.orderItem.id}|}"
+                                  hidden></form>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="grid grid-cols-2 mt-2 gap-2">
+                <button type="button" onclick="history.back();" class="btn btn-outline">
+                    <i class="fa-solid fa-angle-left"></i>
+                    <span class="ml-1">뒤로가기</span>
+                </button>
+                <a href="javascript:;" onclick="RebateForm__submit();" class="btn btn-outline">선택정산</a>
+                <form method="POST" name="rebateForm"  th:action="@{|/trendpick/admin/rebate|}" hidden>
+                    <input type="hidden" name="ids">
+                </form>
+            </div>
+
+            <script>
+                // 전체선택 체크박스
+                const $orderItemCheckboxAll = $('.orderItemCheckboxAll');
+                // 아이템 체크박스
+                const $orderItemCheckbox = $('.orderItemCheckbox');
+
+                $orderItemCheckboxAll.change(function () {
+                    const allChecked = $(this).prop('checked');
+                    $orderItemCheckbox.prop('checked', allChecked); // 아이템 체크박스들에게 체크상태 동기화
+                });
+
+                function OrderItemCheckbox__changed() {
+                    const allChecked = $orderItemCheckbox.length == $('.orderItemCheckbox:checked').length;
+
+                    $orderItemCheckboxAll.prop('checked', allChecked);
+                }
+
+                let RebateForm__submitDone = false;
+
+                function RebateForm__submit() {
+                    if (RebateForm__submitDone) return;
+
+                    const form = document.rebateForm;
+
+                    const $checked = $('.orderItemCheckbox:checked');
+
+                    if ($checked.length == 0) {
+                        alert('정산할 주문품목을 선택해주세요.');
+                        return;
+                    }
+
+                    var confirmAction = confirm("선택 상품들을 정산하시겠습니까?" +
+                        "\n(한 번 정산하면 취소할 수 없습니다.)");
+                    if (confirmAction) {
+                        // 폼 전송
+                        //return true;
+                        const ids = $checked.map((index, el) => $(el).val()).get();
+                        form.ids.value = ids;
+                        form.submit();
+                        RebateForm__submitDone = true;
+                        return true;
+                    } else {
+                        // 폼 전송 후 페이지 이동 취소
+                        setTimeout(function () {
+                            window.stop();
+                        }, 0);
+                        return false;
+                    }
+                }
+
+            </script>
+        </div>
+    </section>
+</main>
+
+</html>

--- a/src/main/resources/templates/trendpick/usr/layout/layout.html
+++ b/src/main/resources/templates/trendpick/usr/layout/layout.html
@@ -161,7 +161,17 @@
                             </li>
                             <li>
                                   <span>
-                                    <a th:href="@{|/trendpick/orders/admin/list?page=0|}"><span>판매내역</span></a>
+                                    <a th:href="@{|/trendpick/admin/makeData|}"><span>정산데이터생성</span></a>
+                                  </span>
+                            </li>
+                            <li>
+                                  <span>
+                                    <a th:href="@{|/trendpick/admin/rebateOrderItemList|}"><span>정산데이터목록</span></a>
+                                  </span>
+                            </li>
+                            <li>
+                                  <span>
+                                    <a th:href="@{|/trendpick/orders/admin/list?page=0|}"><span>판매내역(임시)</span></a>
                                   </span>
                             </li>
                             <li>


### PR DESCRIPTION
- rebate_order_item 정산데이터 테이블을 생성
  - 판매 내역에 대한 테이블을 복제하여 order, order_item, product등 사용자가 직접 사용하는 테이블에 대해 영향이 가지 않도록 한다.
  
- 브랜드 월별 정산 SpringBatch 적용
  - 특정한 시점에 스케줄러를 통해 자동화된 작업을 하기 위해 적용한다.
  - 대용량 일괄처리 및 성능을 위해 적용한다.

- 스케줄러 적용
  - 사용시간이 적은 새벽 4시마다 정산 데이터를 일괄처리 한다.
 