### PR TITLE
bug: 재고 중복감소 로직 제거 (#429)

### DIFF
--- a/src/main/java/project/trendpick_pro/domain/orders/service/impl/OrderServiceImpl.java
+++ b/src/main/java/project/trendpick_pro/domain/orders/service/impl/OrderServiceImpl.java
@@ -29,6 +29,7 @@ import project.trendpick_pro.domain.orders.repository.OrderItemRepository;
 import project.trendpick_pro.domain.orders.repository.OrderRepository;
 import project.trendpick_pro.domain.orders.service.OrderService;
 import project.trendpick_pro.domain.product.entity.product.Product;
+import project.trendpick_pro.domain.product.entity.productOption.ProductOption;
 import project.trendpick_pro.domain.product.exception.ProductNotFoundException;
 import project.trendpick_pro.domain.product.exception.ProductStockOutException;
 import project.trendpick_pro.domain.product.service.ProductService;
@@ -91,6 +92,7 @@ public class OrderServiceImpl implements OrderService {
                             List.of(OrderItem.of(productService.findById(id), quantity, size, color))
                     )
             );
+            log.info("재고 : {}", saveOrder.getOrderItems().get(0).getProduct().getProductOption().getStock());
             OutboxMessage message = createOutboxMessage(saveOrder);
             kafkaProducerService.sendMessage(message.getId());
             return RsData.of("S-1", "주문을 시작합니다.");
@@ -105,7 +107,6 @@ public class OrderServiceImpl implements OrderService {
                 .orElseThrow(() -> new OrderNotFoundException("존재하지 않는 주문 입니다."));
         String email = order.getMember().getEmail();
         try {
-            decreaseStock(order);
             order.updateStatus(OrderStatus.ORDERED);
             sendMessage(order.getId(), "Success", email);
         } catch (ProductStockOutException e) {
@@ -212,16 +213,6 @@ public class OrderServiceImpl implements OrderService {
 
     private void sendMessage(Long orderId, String message, String email) throws JsonProcessingException {
         kafkaProducerService.sendMessage(orderId, message, email);
-    }
-
-    private static void decreaseStock(Order order) {
-        for (OrderItem orderItem : order.getOrderItems()) {
-            orderItem.getProduct().getProductOption().decreaseStock(orderItem.getQuantity());
-            if (orderItem.getProduct().getProductOption().getStock() < 0) {
-                throw new ProductStockOutException("재고가 부족 합니다.");
-            }
-            log.info("재고 : {}", orderItem.getProduct().getProductOption().getStock());
-        }
     }
 
     private Page<OrderResponse> settingOrderByMemberStatus(Member member, int offset) {


### PR DESCRIPTION
# Issue
- #429

## Issue 내용
- 주문시에 상품의 재고가 중복으로 감소하는 이슈가 있었습니다.

## 원인
현재 주문 로직 구조는 이렇습니다.
**1. 결제가 되기전 주문 객체를 생성한다.
2. 주문 객체의 주문 상품이 상품의 재고를 가지고 있게 하여, 재고를 선점하게 한다.
3. 이때 결제 전 주문의 상태는 TEMP 가 된다.
4. 이후 결제가 완료되면 주문의 상태를 ORDERED로 변경한다.**

위 과정에서 2번에서 먼저 상품의 재고가 감소하고, 4번에서도 상품의 재고가 감소 되고 있었습니다.

## 해결방안
4번과정에서 상품의 재고 감소 로직은 불필요한 과정인 부분이라,
해당 부분을 제거하여 중복차감을 방지하였습니다.


**코드의 개선점이나 수정이 필요한 부분에 대한 의견을 주시면 감사하겠습니다.**