### PR TITLE
Fix/431 rebate and withdraw refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+docker-compose.yml
 
 ### STS ###
 .apt_generated

--- a/src/main/java/project/trendpick_pro/domain/cash/entity/CashLog.java
+++ b/src/main/java/project/trendpick_pro/domain/cash/entity/CashLog.java
@@ -6,6 +6,8 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import project.trendpick_pro.domain.member.entity.Member;
+import project.trendpick_pro.domain.rebate.entity.RebateOrderItem;
+import project.trendpick_pro.domain.withdraw.entity.WithdrawApply;
 
 import static jakarta.persistence.FetchType.LAZY;
 
@@ -14,7 +16,7 @@ import static jakarta.persistence.FetchType.LAZY;
 @NoArgsConstructor
 @SuperBuilder
 @ToString(callSuper = true)
-public class CashLog {
+public class CashLog { //돈의 흐름을 기록하기 위한 엔티티
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "cash_log_id")
@@ -31,12 +33,24 @@ public class CashLog {
 
     @Enumerated(EnumType.STRING)
     private EvenType eventType;
-
-    public CashLog(Long id){
-        this.id=id;
-    }
     public enum EvenType {
         출금__통장입금,
         브랜드정산__예치금;
+    }
+
+    static public CashLog of(WithdrawApply withdrawApply){
+        return CashLog.builder()
+                .price(withdrawApply.getPrice() * -1)
+                .relTypeCode(withdrawApply.getBankName())
+                .eventType(EvenType.출금__통장입금)
+                .build();
+    }
+
+    static public CashLog of(RebateOrderItem rebateData){
+        return CashLog.builder()
+                .price(rebateData.calculateRebatePrice())
+                .relTypeCode(rebateData.getSellerName())
+                .eventType(EvenType.브랜드정산__예치금)
+                .build();
     }
 }

--- a/src/main/java/project/trendpick_pro/domain/cash/entity/dto/CashResponse.java
+++ b/src/main/java/project/trendpick_pro/domain/cash/entity/dto/CashResponse.java
@@ -7,7 +7,5 @@ import project.trendpick_pro.domain.cash.entity.CashLog;
 @Getter
 @AllArgsConstructor
 public class CashResponse {
-
     CashLog cashLog;
-    long newRestCash;
 }

--- a/src/main/java/project/trendpick_pro/domain/cash/service/CashService.java
+++ b/src/main/java/project/trendpick_pro/domain/cash/service/CashService.java
@@ -3,9 +3,12 @@ package project.trendpick_pro.domain.cash.service;
 
 import project.trendpick_pro.domain.cash.entity.CashLog;
 import project.trendpick_pro.domain.member.entity.Member;
+import project.trendpick_pro.domain.rebate.entity.RebateOrderItem;
+import project.trendpick_pro.domain.withdraw.entity.WithdrawApply;
 
 
 public interface CashService {
-    CashLog addCash(Member member, long price, String relTypeCode,Long relId, CashLog.EvenType eventType);
+    CashLog addCashLog(WithdrawApply withdrawApply);
 
+    CashLog addCashLog(RebateOrderItem rebateOrderItem);
 }

--- a/src/main/java/project/trendpick_pro/domain/cash/service/impl/CashServiceImpl.java
+++ b/src/main/java/project/trendpick_pro/domain/cash/service/impl/CashServiceImpl.java
@@ -2,26 +2,35 @@ package project.trendpick_pro.domain.cash.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.trendpick_pro.domain.brand.entity.Brand;
+import project.trendpick_pro.domain.brand.service.BrandService;
 import project.trendpick_pro.domain.cash.entity.CashLog;
 import project.trendpick_pro.domain.cash.repository.CashLogRepository;
 import project.trendpick_pro.domain.cash.service.CashService;
 import project.trendpick_pro.domain.member.entity.Member;
+import project.trendpick_pro.domain.member.service.MemberService;
+import project.trendpick_pro.domain.rebate.entity.RebateOrderItem;
+import project.trendpick_pro.domain.withdraw.entity.WithdrawApply;
+
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CashServiceImpl implements CashService {
     private final CashLogRepository cashLogRepository;
-
-    public CashLog addCash(Member member, long price, String relTypeCode, Long relId, CashLog.EvenType eventType) {
-        CashLog cashLog = CashLog.builder()
-                .member(member)
-                .price(price)
-                .relTypeCode(relTypeCode)
-                .relId(relId)
-                .eventType(eventType)
-                .build();
-
-        cashLogRepository.save(cashLog);
-
+    @Transactional
+    @Override
+    public CashLog addCashLog(WithdrawApply withdrawApply) {
+        CashLog cashLog = cashLogRepository.save(CashLog.of(withdrawApply));
         return cashLog;
     }
+
+    @Transactional
+    @Override
+    public CashLog addCashLog(RebateOrderItem rebateOrderItem) {
+        CashLog cashLog = cashLogRepository.save(CashLog.of(rebateOrderItem));
+        return cashLog;
+    }
+
+
 }

--- a/src/main/java/project/trendpick_pro/domain/coupon/service/impl/CouponCardServiceImpl.java
+++ b/src/main/java/project/trendpick_pro/domain/coupon/service/impl/CouponCardServiceImpl.java
@@ -35,10 +35,9 @@ public class CouponCardServiceImpl implements CouponCardService {
                 () -> new CouponNotFoundException("존재하지 않는 쿠폰입니다."));
         int count = couponCardRepository.countByCouponIdAndMemberId(couponId, member.getId());
 
-        RsData<CouponCard> of = validateCouponCard(count, coupon);
-        if (of != null) {
-            return of;
-        }
+        RsData<CouponCard> validateResult = validateCouponCard(count, coupon);
+        if (validateResult != null)
+            return validateResult;
 
         CouponCard savedCouponCard = settingCouponCard(member, dateTime, coupon);
         return RsData.of("S-1", coupon.getName() + " 쿠폰이 발급되었습니다.");
@@ -50,9 +49,9 @@ public class CouponCardServiceImpl implements CouponCardService {
         OrderItem orderItem = orderItemRepository.findById(orderItemId).orElseThrow(
                 () -> new OrderItemNotFoundException("주문되지 않은 상품입니다."));
         CouponCard couponCard = couponCardRepository.findById(couponCardId).orElseThrow(
-                () -> new CouponNotFoundException("존재하지 않은 쿠폰입니다."));
+                () -> new CouponNotFoundException("존재하지 않는 쿠폰입니다."));
         if (!couponCard.validate(orderItem, LocalDateTime.now()))
-            return RsData.of("F-1", "해당 주문상품에 적용된 쿠폰이 없습니다.");
+            return RsData.of("F-1", "해당 주문상품에 해당 쿠폰을 적용할 수 없습니다.");
         couponCard.use(orderItem, LocalDateTime.now());
         return RsData.of("S-1", "쿠폰이 적용되었습니다.");
     }

--- a/src/main/java/project/trendpick_pro/domain/coupon/service/impl/CouponCardServiceImpl.java
+++ b/src/main/java/project/trendpick_pro/domain/coupon/service/impl/CouponCardServiceImpl.java
@@ -35,8 +35,8 @@ public class CouponCardServiceImpl implements CouponCardService {
                 () -> new CouponNotFoundException("존재하지 않는 쿠폰입니다."));
         int count = couponCardRepository.countByCouponIdAndMemberId(couponId, member.getId());
 
-        RsData<CouponCard> validateResult = validateCouponCard(count, coupon);
-        if (validateResult != null)
+        RsData<CouponCard> validateResult = validateCouponCard(count, coupon, dateTime);
+        if (validateResult.isFail())
             return validateResult;
 
         CouponCard savedCouponCard = settingCouponCard(member, dateTime, coupon);
@@ -82,14 +82,14 @@ public class CouponCardServiceImpl implements CouponCardService {
         return savedCouponCard;
     }
 
-    private static RsData<CouponCard> validateCouponCard(int count, Coupon coupon) {
+    private static RsData<CouponCard> validateCouponCard(int count, Coupon coupon, LocalDateTime dateTime) {
         if(count > 0)
             return RsData.of("F-3", "이미 발급 받으신 쿠폰입니다.");
         if(!coupon.validateLimitCount())
             return RsData.of("F-1", "수량이 모두 소진되었습니다.");
-        if(!coupon.validateLimitIssueDate(LocalDateTime.now()))
+        if(!coupon.validateLimitIssueDate(dateTime))
             return RsData.of("F-2", "쿠폰 발급 가능 날짜가 지났습니다.");
-        return null;
+        return RsData.success();
     }
 
     private List<CouponCardByApplyResponse> createCouponCardByApplyResponseList(List<CouponCard> couponCards, OrderItem orderItem) {

--- a/src/main/java/project/trendpick_pro/domain/delivery/entity/Delivery.java
+++ b/src/main/java/project/trendpick_pro/domain/delivery/entity/Delivery.java
@@ -26,7 +26,7 @@ public class Delivery extends BaseTimeEntity {
 
     public Delivery(String address){
         this.address = address;
-        state = DeliveryState.READY;
+        state = DeliveryState.COMPLETED; //원활한 테스트를 위해서 배송 완료로 임시 설정
     }
 
     public void updateStatus(String status){

--- a/src/main/java/project/trendpick_pro/domain/member/service/MemberService.java
+++ b/src/main/java/project/trendpick_pro/domain/member/service/MemberService.java
@@ -1,14 +1,11 @@
 package project.trendpick_pro.domain.member.service;
 
-import project.trendpick_pro.domain.brand.entity.Brand;
-import project.trendpick_pro.domain.cash.entity.CashLog;
-import project.trendpick_pro.domain.cash.entity.dto.CashResponse;
 import project.trendpick_pro.domain.member.entity.Member;
 import project.trendpick_pro.domain.member.entity.dto.response.MemberInfoResponse;
 import project.trendpick_pro.domain.member.entity.form.JoinForm;
 import project.trendpick_pro.domain.tags.tag.entity.dto.request.TagRequest;
+import project.trendpick_pro.domain.withdraw.entity.WithdrawApply;
 import project.trendpick_pro.global.util.rsData.RsData;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -19,9 +16,9 @@ public interface MemberService {
     void modifyTag(Member member, TagRequest tagRequest);
     RsData<MemberInfoResponse> modifyAddress(Member member, String address);
     Member findById(Long id);
-    Member findByBrandMember(String name);
+    Member findBrandMember(String name);
     Optional<Member> findByEmail(String username);
     void updateRecentlyAccessDate(Member member, LocalDateTime dateTime);
-    RsData<CashResponse> addCash(String brand, long price, Brand relEntity, CashLog.EvenType eventType);
     long getRestCash(Member member);
+    void completeWithdraw(WithdrawApply withdrawApply);
 }

--- a/src/main/java/project/trendpick_pro/domain/orders/entity/Order.java
+++ b/src/main/java/project/trendpick_pro/domain/orders/entity/Order.java
@@ -129,4 +129,9 @@ public class Order extends BaseTimeEntity {
         orderItems.add(orderItem);
         orderItem.connectOrder(this);
     }
+
+    //구매결정 완료된건지 (환불불가, 취소불가)
+    public boolean isCompletedPurchaseDecision(){
+        return this.getDeliveryState().equals("배송완료") && this.getOrderState().equals("결제완료");
+    }
 }

--- a/src/main/java/project/trendpick_pro/domain/orders/service/impl/OrderServiceImpl.java
+++ b/src/main/java/project/trendpick_pro/domain/orders/service/impl/OrderServiceImpl.java
@@ -1,13 +1,11 @@
 package project.trendpick_pro.domain.orders.service.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import project.trendpick_pro.domain.cart.entity.CartItem;
@@ -21,7 +19,6 @@ import project.trendpick_pro.domain.orders.entity.OrderItem;
 import project.trendpick_pro.domain.orders.entity.OrderStatus;
 import project.trendpick_pro.domain.orders.entity.dto.request.CartToOrderRequest;
 import project.trendpick_pro.domain.orders.entity.dto.request.OrderSearchCond;
-import project.trendpick_pro.domain.orders.entity.dto.request.OrderStateResponse;
 import project.trendpick_pro.domain.orders.entity.dto.response.OrderDetailResponse;
 import project.trendpick_pro.domain.orders.entity.dto.response.OrderResponse;
 import project.trendpick_pro.domain.orders.exception.OrderNotFoundException;
@@ -44,7 +41,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Transactional(readOnly = true)
@@ -84,11 +80,11 @@ public class OrderServiceImpl implements OrderService {
     }
 
     @Transactional
-    public RsData productToOrder(Member member, Long id, int quantity, String size, String color) {
+    public RsData productToOrder(Member member, Long productId, int quantity, String size, String color) {
         try {
             Order saveOrder = orderRepository.save(
                     Order.createOrder(member, new Delivery(member.getAddress()),
-                            List.of(OrderItem.of(productService.findById(id), quantity, size, color))
+                            List.of(OrderItem.of(productService.findById(productId), quantity, size, color))
                     )
             );
             OutboxMessage message = createOutboxMessage(saveOrder);

--- a/src/main/java/project/trendpick_pro/domain/rebate/entity/RebateOrderItem.java
+++ b/src/main/java/project/trendpick_pro/domain/rebate/entity/RebateOrderItem.java
@@ -43,15 +43,16 @@ public class RebateOrderItem extends BaseTimeEntity {
     @OneToOne(fetch = LAZY)
     @JoinColumn(name = "coupon_card_id")
     private CouponCard couponCard;
-    @Column(name = "order_price", nullable = false)
-    private int orderPrice;
-
     @Column(name = "total_price")
-    private int totalPrice;
-
+    private int totalPrice; //전체금액 (할인제외)
+    @Column(name = "order_price", nullable = false)
+    private int orderPrice; //주문금액 (할인 계산된 금액)
     @Column(name = "discount_price")
-    private int discountPrice;
+    private int discountPrice; //할인 받은 금액
 
+    // 상품
+    @Column(name = "product_subject", nullable = false)
+    private String productSubject;
     @Column(name = "size", nullable = false)
     private String size;
 
@@ -60,14 +61,11 @@ public class RebateOrderItem extends BaseTimeEntity {
 
     @Column(name = "count", nullable = false)
     private int quantity;
-
-    @ManyToOne(fetch = LAZY)
+    @OneToOne(fetch = LAZY)
     @ToString.Exclude
     @JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private CashLog rebateCashLog; // 정산에 관련된 환급지급내역
     private LocalDateTime rebateDate;
-    // 상품
-    private String productSubject;
 
     // 주문품목
     private LocalDateTime orderItemCreateDate;
@@ -113,18 +111,18 @@ public class RebateOrderItem extends BaseTimeEntity {
     }
 
     public int calculateRebatePrice() {
-        return (totalPrice*quantity) - (int)(totalPrice * 0.05); // 정산금액 수수료 0.05% 제외하고 계산
+        return (totalPrice*quantity - discountPrice) - (int)(totalPrice * 0.05); // 정산금액 수수료 5%(임의) 제외하고 계산
     }
-    public boolean isRebateAvailable() {
+    public boolean checkAlreadyRebate() {
         if (rebateDate != null) {
             return false;
         }
         return true;
     }
 
-    public void setRebateDone(Long cashLogId) {
+    public void setRebateDone(CashLog cashLog) {
         rebateDate = LocalDateTime.now();
-        this.rebateCashLog = new CashLog(cashLogId);
+        this.rebateCashLog = cashLog;
     }
 
     public boolean isRebateDone() {

--- a/src/main/java/project/trendpick_pro/domain/rebate/service/RebateService.java
+++ b/src/main/java/project/trendpick_pro/domain/rebate/service/RebateService.java
@@ -7,12 +7,7 @@ import project.trendpick_pro.global.util.rsData.RsData;
 import java.util.List;
 
 public interface RebateService {
-    RsData makeDate(String brandName,String yearMonth);
-
-    void makeRebateOrderItem(RebateOrderItem item);
-
-    RebateOrderItem toRebateOrderItem(OrderItem orderItem);
-
-    List<RebateOrderItem> findRebateOrderItemsByCreatedDateIn(String brandName,String yearMonth);
-    RsData rebate(long orderItemId);
+    RsData makeData(String brandName,String yearMonth);
+    List<RebateOrderItem> findRebateDataByCurrentYearMonth(String brandName,String yearMonth);
+    RsData rebate(Long orderItemId);
 }

--- a/src/main/java/project/trendpick_pro/domain/rebate/service/impl/RebateServiceImpl.java
+++ b/src/main/java/project/trendpick_pro/domain/rebate/service/impl/RebateServiceImpl.java
@@ -4,37 +4,40 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import project.trendpick_pro.domain.cash.entity.CashLog;
-import project.trendpick_pro.domain.member.service.MemberService;
+import project.trendpick_pro.domain.cash.service.CashService;
 import project.trendpick_pro.domain.orders.entity.OrderItem;
 import project.trendpick_pro.domain.orders.service.OrderService;
 import project.trendpick_pro.domain.rebate.entity.RebateOrderItem;
 import project.trendpick_pro.domain.rebate.repository.RebateOrderItemRepository;
 import project.trendpick_pro.domain.rebate.service.RebateService;
+import project.trendpick_pro.domain.store.service.StoreService;
 import project.trendpick_pro.global.util.rsData.RsData;
 import project.trendpick_pro.global.util.Ut;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class RebateServiceImpl implements RebateService {
-    private final OrderService orderService;
-    private final MemberService memberService;
     private final RebateOrderItemRepository rebateOrderItemRepository;
+    private final OrderService orderService;
+    private final CashService cashService;
+    private final StoreService storeService;
 
     @Transactional
-    public RsData makeDate(String brandName, String yearMonth) {
+    @Override
+    public RsData makeData(String brandName, String yearMonth) {
         String fromDateStr = yearMonth + "-01 00:00:00.000000";
         String toDateStr = yearMonth + "-%02d 23:59:59.999999".formatted(Ut.date.getEndDayOf(yearMonth));
         List<OrderItem> orderItems = orderService.findAllByCreatedDateBetweenOrderByIdAsc(
                 Ut.date.parse(fromDateStr), Ut.date.parse(toDateStr)
         );
 
-        if(orderItems.isEmpty()){
+        if(orderItems.isEmpty())
             return RsData.of("F-1","정산할 주문내역이 없습니다.");
-        }
+
         List<OrderItem> brandOrderItems=new ArrayList<>();
         for(OrderItem item: orderItems) {
             if (item.getProduct().getProductOption().getBrand().getName().equals(brandName)) {
@@ -47,62 +50,69 @@ public class RebateServiceImpl implements RebateService {
                 .map(this::toRebateOrderItem)
                 .toList();
 
-        rebateOrderItems.forEach(this::makeRebateOrderItem);
+        rebateOrderItems.forEach(this::updateOrCreateRebateData);
         return RsData.of("S-1", "정산데이터가 성공적으로 생성되었습니다.");
     }
 
     @Transactional
-    public void makeRebateOrderItem(RebateOrderItem item) {
+    @Override
+    public RsData rebate(Long orderItemId) {
+        RebateOrderItem rebateOrderItem = rebateOrderItemRepository.findByOrderItemId(orderItemId).orElse(null);
+
+        RsData<Object> validateResult = validateAvailableRebate(rebateOrderItem);
+        if (validateResult.isFail()) return validateResult;
+
+        //캐시로그 생성
+        CashLog cashLog = cashService.addCashLog(rebateOrderItem);
+        //스토어 정산캐시 추가
+        storeService.addRebateCash(rebateOrderItem.getSellerName(), rebateOrderItem.calculateRebatePrice());
+        //정산완료
+        rebateOrderItem.setRebateDone(cashLog);
+        return RsData.of(
+                "S-1",
+                "주문품목번호 %d번에 대해서 정산을 완료하였습니다.".formatted(rebateOrderItem.getOrderItem().getId())
+        );
+    }
+
+    @Override
+    public List<RebateOrderItem> findRebateDataByCurrentYearMonth(String brandName,String yearMonth) {
+        int monthEndDay = Ut.date.getEndDayOf(yearMonth);
+        String fromDateStr = yearMonth + "-01 00:00:00.000000";
+        String toDateStr = yearMonth + "-%02d 23:59:59.999999".formatted(monthEndDay);
+        LocalDateTime fromDate = Ut.date.parse(fromDateStr); //yyyy-MM-dd HH:mm:ss.SSSSSS 패턴으로 만들기
+        LocalDateTime toDate = Ut.date.parse(toDateStr);
+
+        return rebateOrderItemRepository.findAllByCreatedDateBetweenAndSellerNameOrderByIdAsc(fromDate, toDate, brandName);
+    }
+
+
+    private static RsData<Object> validateAvailableRebate(RebateOrderItem rebateOrderItem) {
+        if(rebateOrderItem == null)
+            return RsData.of("F-2", "존재하지 않는 정산 데이터입니다.");
+        if (!rebateOrderItem.checkAlreadyRebate())
+            return RsData.of("F-1", "이미 정산된 데이터입니다.");
+        if(!rebateOrderItem.getOrder().isCompletedPurchaseDecision())
+            return RsData.of("F-3", "구매결정이 완료되지 않은 데이터입니다.");
+        return RsData.success();
+    }
+
+    private void updateOrCreateRebateData(RebateOrderItem item) {
+        //orderItem의 id값으로 조회해봐서 이미 정산데이터로 생성되어 있다면, 업데이트 처리
         RebateOrderItem oldRebateOrderItem = rebateOrderItemRepository.findByOrderItemId(item.getOrderItem().getId()).orElse(null);
         if (oldRebateOrderItem != null) {
             if (oldRebateOrderItem.isRebateDone()) {
                 return;
             }
+
             oldRebateOrderItem.updateWith(item);
             rebateOrderItemRepository.save(oldRebateOrderItem);
         } else {
             rebateOrderItemRepository.save(item);
         }
     }
-    @Transactional
-    public RebateOrderItem toRebateOrderItem(OrderItem orderItem) {
+
+    private RebateOrderItem toRebateOrderItem(OrderItem orderItem) {
         return new RebateOrderItem(orderItem);
     }
 
-    @Transactional(readOnly = true)
-    public List<RebateOrderItem> findRebateOrderItemsByCreatedDateIn(String brandName,String yearMonth) {
-        int monthEndDay = Ut.date.getEndDayOf(yearMonth);
-
-        String fromDateStr = yearMonth + "-01 00:00:00.000000";
-        String toDateStr = yearMonth + "-%02d 23:59:59.999999".formatted(monthEndDay);
-        LocalDateTime fromDate = Ut.date.parse(fromDateStr);
-        LocalDateTime toDate = Ut.date.parse(toDateStr);
-
-        return rebateOrderItemRepository.findAllByCreatedDateBetweenAndSellerNameOrderByIdAsc(fromDate, toDate,brandName);
-    }
-
-    @Transactional
-    public RsData rebate(long orderItemId) {
-        RebateOrderItem rebateOrderItem = rebateOrderItemRepository.findByOrderItemId(orderItemId).get();
-
-        if (!rebateOrderItem.isRebateAvailable()) {
-            return RsData.of("F-1", "정산을 할 수 없는 상태입니다.");
-        }
-
-        int calculateRebatePrice = rebateOrderItem.calculateRebatePrice();
-
-        CashLog cashLog = memberService.addCash(
-                rebateOrderItem.getSellerName(),
-                calculateRebatePrice,
-                rebateOrderItem.getSeller(),
-                CashLog.EvenType.브랜드정산__예치금
-        ).getData().getCashLog();
-
-
-        rebateOrderItem.setRebateDone(cashLog.getId());
-        return RsData.of(
-                "S-1",
-                "주문품목번호 %d번에 대해서 정산을 완료하였습니다.".formatted(rebateOrderItem.getOrderItem().getId())
-        );
-    }
 }

--- a/src/main/java/project/trendpick_pro/domain/store/entity/Store.java
+++ b/src/main/java/project/trendpick_pro/domain/store/entity/Store.java
@@ -15,10 +15,24 @@ public class Store extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true)
+    @Column(name = "brand", unique = true)
     private String brand;
+
+    //정산 데이터 생성 -> 정산처리 -> 캐시 처리
+    @Column(name = "rebate_cash")
+    private int rebatedCash;
 
     public Store(String brand){
         this.brand = brand;
+    }
+
+    public void addRebatedCash(int price) {
+        this.rebatedCash += price;
+    }
+
+    public void withdrawRebatedCash(int price){
+        if(this.rebatedCash <= price)
+            throw new IllegalArgumentException("출금 요청한 금액이 정산 금액보다 많습니다.");
+        this.rebatedCash -= price;
     }
 }

--- a/src/main/java/project/trendpick_pro/domain/store/service/StoreService.java
+++ b/src/main/java/project/trendpick_pro/domain/store/service/StoreService.java
@@ -5,4 +5,6 @@ import project.trendpick_pro.domain.store.entity.Store;
 public interface StoreService {
     Store save(Store store);
     Store findByBrand(String storeName);
+    void addRebateCash(String storeName, int calculateRebatePrice);
+    int getRestCash(String storeName);
 }

--- a/src/main/java/project/trendpick_pro/domain/store/service/impl/StoreServiceImpl.java
+++ b/src/main/java/project/trendpick_pro/domain/store/service/impl/StoreServiceImpl.java
@@ -9,6 +9,7 @@ import project.trendpick_pro.domain.store.service.StoreService;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class StoreServiceImpl implements StoreService {
     private final StoreRepository storeRepository;
 
@@ -19,10 +20,21 @@ public class StoreServiceImpl implements StoreService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public Store findByBrand(String storeName) {
         return storeRepository.findByBrand(storeName).orElseThrow(
                 () -> new IllegalArgumentException("해당 스토어는 존재하지 않는 스토어입니다.")
         );
+    }
+
+    @Override
+    @Transactional
+    public void addRebateCash(String storeName, int calculateRebatePrice) {
+        Store store = findByBrand(storeName);
+        store.addRebatedCash(calculateRebatePrice);
+    }
+
+    @Override
+    public int getRestCash(String storeName) {
+        return findByBrand(storeName).getRebatedCash();
     }
 }

--- a/src/main/java/project/trendpick_pro/domain/withdraw/controller/AdmWithdrawController.java
+++ b/src/main/java/project/trendpick_pro/domain/withdraw/controller/AdmWithdrawController.java
@@ -26,12 +26,13 @@ public class AdmWithdrawController {
     @PreAuthorize("hasAuthority({'ADMIN', 'BRAND_ADMIN'})")
     @GetMapping("/withDrawList")
     public String showApplyList(Model model) {
-        Member member=rq.getRollMember();
+        Member member= rq.getAdmin();
         List<WithdrawApply> withdrawApplies;
+
         if(member.getRole().getValue().equals("ADMIN")) {
             withdrawApplies = withdrawService.findAll();
         }else{
-            withdrawApplies=withdrawService.findByWithdrawApplyId(member.getId());
+            withdrawApplies=withdrawService.findAllWithdrawByApplicantId(member.getId());
         }
         model.addAttribute("withdrawApplies", withdrawApplies);
         return "trendpick/admin/withDrawList";

--- a/src/main/java/project/trendpick_pro/domain/withdraw/controller/WithdrawController.java
+++ b/src/main/java/project/trendpick_pro/domain/withdraw/controller/WithdrawController.java
@@ -24,30 +24,20 @@ import project.trendpick_pro.global.util.rsData.RsData;
 public class WithdrawController {
 
     private final WithdrawService withdrawService;
-    private final MemberService memberService;
     private final Rq rq;
 
     @PreAuthorize("hasAuthority({'BRAND_ADMIN'})")
     @GetMapping("/withDraw")
-    public String showApply(Model model) {
-        Member member = rq.getRollMember();
-        if(!member.getRole().getValue().equals("BRAND_ADMIN")){
-            return rq.historyBack("브랜드 관리자만 접근할 수 있습니다.");
-        }
-        model.addAttribute("actorRestCash", memberService.getRestCash(member));
+    public String showApplyForm(Model model) {
+        model.addAttribute("actorRestCash", withdrawService.showRestCash(rq.getBrandMember()));
         return "trendpick/admin/withDraw";
     }
 
     @PreAuthorize("hasAuthority({'BRAND_ADMIN'})")
     @PostMapping("/withDraw")
     public String apply(@Valid WithDrawApplyForm withDrawApplyForm) {
-        RsData<WithdrawApply> rsData = withdrawService.apply(
-                withDrawApplyForm.getBankName(),
-                withDrawApplyForm.getBankAccountNo(),
-                withDrawApplyForm.getPrice(),
-                rq.getBrandMember()
-        );
+        withdrawService.apply(withDrawApplyForm, rq.getBrandMember());
 
-        return rq.redirectWithMsg("/trendpick/admin/withDrawList","출금 신청이 완료되었습니다.");
+        return rq.redirectWithMsg("/trendpick/admin/withDrawList", "출금 신청이 완료되었습니다.");
     }
 }

--- a/src/main/java/project/trendpick_pro/domain/withdraw/entity/WithdrawApply.java
+++ b/src/main/java/project/trendpick_pro/domain/withdraw/entity/WithdrawApply.java
@@ -5,6 +5,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import project.trendpick_pro.domain.cash.entity.CashLog;
 import project.trendpick_pro.domain.member.entity.Member;
+import project.trendpick_pro.domain.withdraw.entity.dto.WithDrawApplyForm;
 
 import java.time.LocalDateTime;
 
@@ -35,18 +36,19 @@ public class WithdrawApply {
     private LocalDateTime cancelDate;
     private String msg;
 
-    public boolean isApplyDoneAvailable() {
+    public boolean checkAlreadyProcessed() { //이미 처리되었는지 확인
         if (withdrawDate != null || withdrawCashLog != null || cancelDate != null) {
-            return false;
+            return true;
         }
 
-        return true;
+        return false;
     }
 
-    public void setApplyDone(Long cashLogId, String msg) {
+    public void setApplyDone(CashLog cashLog, String msg) {
         withdrawDate = LocalDateTime.now();
-        this.withdrawCashLog = new CashLog(cashLogId);
+        this.withdrawCashLog = cashLog;
         this.msg = msg;
+
     }
 
     public void setCancelDone(String msg) {
@@ -54,8 +56,13 @@ public class WithdrawApply {
         this.msg = msg;
     }
 
-    public boolean isCancelAvailable() {
-        return isApplyDoneAvailable();
+    static public WithdrawApply of(WithDrawApplyForm withDrawApplyForm, Member applicant){
+        return WithdrawApply.builder()
+                .bankName(withDrawApplyForm.getBankName())
+                .bankAccountNo(withDrawApplyForm.getBankAccountNo())
+                .price(withDrawApplyForm.getPrice())
+                .applicant(applicant)
+                .build();
     }
 
     public boolean isApplyDone() {

--- a/src/main/java/project/trendpick_pro/domain/withdraw/service/WithdrawService.java
+++ b/src/main/java/project/trendpick_pro/domain/withdraw/service/WithdrawService.java
@@ -2,14 +2,16 @@ package project.trendpick_pro.domain.withdraw.service;
 
 import project.trendpick_pro.domain.member.entity.Member;
 import project.trendpick_pro.domain.withdraw.entity.WithdrawApply;
+import project.trendpick_pro.domain.withdraw.entity.dto.WithDrawApplyForm;
 import project.trendpick_pro.global.util.rsData.RsData;
 
 import java.util.List;
 
 public interface WithdrawService {
-    RsData<WithdrawApply> apply(String bankName, String bankAccountNo, Integer price, Member applicant);
+    RsData<WithdrawApply> apply(WithDrawApplyForm withDrawApplyForm, Member applicant);
     List<WithdrawApply> findAll();
-    List<WithdrawApply> findByWithdrawApplyId(Long id);
+    List<WithdrawApply> findAllWithdrawByApplicantId(Long id);
     RsData withdraw(Long withdrawApplyId);
     RsData cancelApply(Long withdrawApplyId);
+    int showRestCash(Member brandMember);
 }

--- a/src/main/java/project/trendpick_pro/global/util/rq/Rq.java
+++ b/src/main/java/project/trendpick_pro/global/util/rq/Rq.java
@@ -79,15 +79,7 @@ public class Rq {
         return getLogin().getRole().equals(MemberRoleType.ADMIN);
     }
     public Member getRollMember(){
-        Member member=getLogin();
-        if(member.getRole().equals(MemberRoleType.MEMBER)){
-            return member;
-        } else if(member.getRole().equals(MemberRoleType.BRAND_ADMIN)){
-            return member;
-        } else if(member.getRole().equals(MemberRoleType.ADMIN)){
-            return member;
-        }
-        throw new MemberNotMatchException("허용된 권한이 아닙니다.");
+        return getLogin();
     }
     public Member getBrandMember() {
         Member member = getLogin();

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,9 +1,9 @@
 spring:
   datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:test;
-    username: sa
-    password:
+    driver-class-name: ${db.driver}
+    url: ${db.url}
+    username: ${db.username}
+    password: ${db.password}
   jpa:
     hibernate:
       ddl-auto: create

--- a/src/main/resources/templates/trendpick/admin/rebateOrderItemList.html
+++ b/src/main/resources/templates/trendpick/admin/rebateOrderItemList.html
@@ -54,7 +54,7 @@
                     <tbody>
                     <tr th:each="item : ${items}">
                         <td>
-                            <input onchange="OrderItemCheckbox__changed();" th:if="${item.rebateAvailable}"
+                            <input onchange="OrderItemCheckbox__changed();" th:if="${item.checkAlreadyRebate}"
                                    type="checkbox" class="orderItemCheckbox checkbox" th:value="${item.orderItem.id}">
                         </td>
                         <td th:text="${item.orderItem.id}"></td>
@@ -65,7 +65,7 @@
                         <td th:text="${#numbers.formatDecimal(item.calculateRebatePrice(), 0, 'COMMA', 0, 'POINT')} + ' 원 '"></td>
                         <td th:text="${#temporals.format(item.rebateDate, 'yy-MM-dd HH:mm')}"></td>
                         <td>
-                            <a th:if="${item.rebateAvailable}" href="javascript:;" onclick="$(this).next().submit();"
+                            <a th:if="${item.checkAlreadyRebate}" href="javascript:;" onclick="$(this).next().submit();"
                                class="btn btn-primary btn-xs">정산</a>
                             <form method="POST" th:action="@{|/trendpick/admin/rebateOne/${item.orderItem.id}|}"
                                   hidden></form>

--- a/src/main/resources/templates/trendpick/usr/layout/layout.html
+++ b/src/main/resources/templates/trendpick/usr/layout/layout.html
@@ -145,12 +145,12 @@
                             </li>
                             <li>
                                   <span>
-                                    <a th:href="@{/trendpick/coupons/list}"><span>받을 수 있는 쿠폰목록</span></a>
+                                    <a th:href="@{/trendpick/coupons/list}"><span>쿠폰목록</span></a>
                                   </span>
                             </li>
                         </ul>
                     </div>
-                    <div class="dropdown dropdown-bottom dropdown-end" th:unless="${@rq.checkMember()}">
+                    <div class="dropdown dropdown-bottom dropdown-end" th:if="${@rq.checkBrand()}">
                         <label tabindex="0" class="btn btn-ghost btn-circle">
                             <i class="fa-solid fa-bars"></i>
                         </label>
@@ -173,7 +173,7 @@
                             </li>
                             <li>
                                   <span>
-                                    <a th:href="@{|/trendpick/admin/withDraw|}"><span>출금</span></a>
+                                    <a th:href="@{|/trendpick/admin/withDraw|}"><span>출금신청</span></a>
                                   </span>
                             </li>
                             <li>
@@ -189,6 +189,29 @@
                             <li>
                                   <span>
                                     <a th:href="@{|/trendpick/coupons/${@rq.getBrandName()}/generate|}"><span>쿠폰발급</span></a>
+                                  </span>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="dropdown dropdown-bottom dropdown-end" th:if="${@rq.checkAdmin()}">
+                        <label tabindex="0" class="btn btn-ghost btn-circle">
+                            <i class="fa-solid fa-bars"></i>
+                        </label>
+                        <ul tabindex="0"
+                            class="menu menu-compact dropdown-content mt-3 p-2 shadow bg-base-100 rounded-box w-64">
+                            <li>
+                                  <span>
+                                    <a th:href=""><span>회원관리</span></a>
+                                  </span>
+                            </li>
+                            <li>
+                                  <span>
+                                    <a th:href=""><span>스토어관리</span></a>
+                                  </span>
+                            </li>
+                            <li>
+                                  <span>
+                                    <a th:href=""><span>출금신청목록</span></a>
                                   </span>
                             </li>
                         </ul>


### PR DESCRIPTION
## 내용
- 정산데이터 생성 후 정산처리에서 생기는 이슈를 해결했습니다.
- 정산 후 캐시가 쌓이지 않던 이슈를 해결했습니다.
- 정산 -> 캐시 -> 출금 프로세스를 재정리하였습니다. 
- brand_admin과 admin을 분리하였습니다. ( admin은 개발이 되어있지 않습니다.)
- Rebate, CashLog, Withdraw 도메인을 리팩토링 하였습니다. (변수명 변경, SRP적용, 캡슐화 등)

### 정산 -> 캐시 -> 출금 프로세스 정리
- 스토어(브랜드관리자 계정)는 yy/mm 별로 판매내역 현황을 조회할 수 있습니다.
- 정산은 주문결정완료 상태 (주문완료/배송완료)인 데이터만 실제 정산 처리할 수 있습니다.
- 정산처리는 관리자가 확인할 수 있는 CashLog로 기록을 남기고 수수료 정산 후 스토어에게 캐시로 변환됩니다.
- 스토어(브랜드관리자 계정)는 해당 캐시를 출금요청이 가능합니다.
- Admin(전체관리자) 는 출금을 승인할 수 있습니다.

확인 후 merge부탁드릴게요 !
피드백과 질문이 있으시면 말씀해주시면 감사하겠습니다.
close #431 