### PR TITLE
Refactor/439 정산 프로세스 오류 수정 및 개편

### DIFF
--- a/src/main/java/project/trendpick_pro/domain/brand/service/BrandService.java
+++ b/src/main/java/project/trendpick_pro/domain/brand/service/BrandService.java
@@ -13,4 +13,5 @@ public interface BrandService {
     Brand findByName(String name);
     Brand findById(Long id);
     Long count();
+    void saveAll(List<String> brands);
 }

--- a/src/main/java/project/trendpick_pro/domain/brand/service/impl/BrandServiceImpl.java
+++ b/src/main/java/project/trendpick_pro/domain/brand/service/impl/BrandServiceImpl.java
@@ -7,48 +7,51 @@ import project.trendpick_pro.domain.brand.entity.Brand;
 import project.trendpick_pro.domain.brand.entity.dto.BrandResponse;
 import project.trendpick_pro.domain.brand.repository.BrandRepository;
 import project.trendpick_pro.domain.brand.service.BrandService;
+import project.trendpick_pro.domain.store.entity.Store;
+import project.trendpick_pro.domain.store.repository.StoreRepository;
+import project.trendpick_pro.global.basedata.tagname.entity.TagName;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class BrandServiceImpl implements BrandService {
-    
+
     private final BrandRepository brandRepository;
+    private final StoreRepository storeRepository;
 
     @Transactional(readOnly = true)
     @Override
-    public boolean isPresent(String name){
+    public boolean isPresent(String name) {
         return brandRepository.findByName(name).isPresent();
     }
 
     @Transactional
     @Override
-    public void save(String name){
+    public void save(String name) {
         brandRepository.save(new Brand(name));
     }
 
     @Transactional
     @Override
-    public void delete(Long id){
+    public void delete(Long id) {
         Brand brand = brandRepository.findById(id).orElseThrow();
         brandRepository.delete(brand);
     }
 
     @Transactional(readOnly = true)
     @Override
-    public List<BrandResponse> findAll(){
+    public List<BrandResponse> findAll() {
         return brandRepository.findAllBy();
     }
 
     @Transactional(readOnly = true)
     @Override
     public Brand findByName(String name) {
-        try {
-            return brandRepository.findByName(name).get();
-        } catch (Exception e) {
-            return brandRepository.save(new Brand(name));
-        }
+        return brandRepository.findByName(name).orElseThrow(
+                () -> new IllegalArgumentException("해당 브랜드는 존재하지 않습니다.")
+        );
     }
 
     @Transactional(readOnly = true)
@@ -61,5 +64,16 @@ public class BrandServiceImpl implements BrandService {
     @Override
     public Long count() {
         return brandRepository.count();
+    }
+
+    @Override
+    @Transactional
+    public void saveAll(List<String> brands) {
+        List<Brand> list = new ArrayList<>();
+        for (String brand : brands) {
+            list.add(new Brand(brand));
+        }
+
+        brandRepository.saveAll(list);
     }
 }

--- a/src/main/java/project/trendpick_pro/domain/cash/entity/CashLog.java
+++ b/src/main/java/project/trendpick_pro/domain/cash/entity/CashLog.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import project.trendpick_pro.domain.common.base.BaseTimeEntity;
 import project.trendpick_pro.domain.member.entity.Member;
 import project.trendpick_pro.domain.rebate.entity.RebateOrderItem;
 import project.trendpick_pro.domain.withdraw.entity.WithdrawApply;
@@ -16,20 +17,18 @@ import static jakarta.persistence.FetchType.LAZY;
 @NoArgsConstructor
 @SuperBuilder
 @ToString(callSuper = true)
-public class CashLog { //돈의 흐름을 기록하기 위한 엔티티
+public class CashLog extends BaseTimeEntity { //돈의 흐름을 기록하기 위한 엔티티
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "cash_log_id")
     private Long id;
 
-    private String relTypeCode;
-
-    private Long relId;
-
     @ManyToOne(fetch = LAZY)
     private Member member;
-
+    private String store;
     private long price; // 변동
+    private Long rebateOrderItemId;
+    private Long withDrawApplyId;
 
     @Enumerated(EnumType.STRING)
     private EvenType eventType;
@@ -40,16 +39,18 @@ public class CashLog { //돈의 흐름을 기록하기 위한 엔티티
 
     static public CashLog of(WithdrawApply withdrawApply){
         return CashLog.builder()
+                .withDrawApplyId(withdrawApply.getId())
                 .price(withdrawApply.getPrice() * -1)
-                .relTypeCode(withdrawApply.getBankName())
+                .store(withdrawApply.getStore())
                 .eventType(EvenType.출금__통장입금)
                 .build();
     }
 
-    static public CashLog of(RebateOrderItem rebateData){
+    static public CashLog of(RebateOrderItem rebateOrderItem){
         return CashLog.builder()
-                .price(rebateData.calculateRebatePrice())
-                .relTypeCode(rebateData.getSellerName())
+                .rebateOrderItemId(rebateOrderItem.getId())
+                .price(rebateOrderItem.calculateRebatePrice())
+                .store(rebateOrderItem.getSellerName())
                 .eventType(EvenType.브랜드정산__예치금)
                 .build();
     }

--- a/src/main/java/project/trendpick_pro/domain/coupon/entity/CouponCard.java
+++ b/src/main/java/project/trendpick_pro/domain/coupon/entity/CouponCard.java
@@ -66,11 +66,6 @@ public class CouponCard extends BaseTimeEntity {
     public void use(OrderItem orderItem, LocalDateTime dateTime) {
         settingStatusAndDate(dateTime);
         orderItem.applyCouponCard(this);
-        int discountPercent = this.coupon.getDiscountPercent();
-        int price = orderItem.getOrderPrice() * discountPercent / 100;
-        orderItem.discount(
-                price
-        );
     }
 
     public void cancel(OrderItem orderItem){

--- a/src/main/java/project/trendpick_pro/domain/orders/entity/Order.java
+++ b/src/main/java/project/trendpick_pro/domain/orders/entity/Order.java
@@ -121,7 +121,7 @@ public class Order extends BaseTimeEntity {
     private void settingOrderItems(List<OrderItem> orderItems) {
         for (OrderItem orderItem : orderItems) {
             this.addOrderItem(orderItem);
-            this.totalPrice += orderItem.getOrderItemByQuantity();
+            this.totalPrice += orderItem.getTotalPrice();
         }
     }
 

--- a/src/main/java/project/trendpick_pro/domain/orders/entity/OrderItem.java
+++ b/src/main/java/project/trendpick_pro/domain/orders/entity/OrderItem.java
@@ -33,7 +33,7 @@ public class OrderItem extends BaseTimeEntity {
     @Column(name = "order_price", nullable = false)
     private int orderPrice;
 
-    private int orderItemByQuantity;
+    private int totalPrice; //계산된 가격 (실제 지불한)
 
     @Column(name = "discount_price", nullable = false)
     private int discountPrice;
@@ -68,6 +68,9 @@ public class OrderItem extends BaseTimeEntity {
 
     public void applyCouponCard(CouponCard couponCard) {
         this.couponCard = couponCard;
+        int discountPercent = couponCard.getCoupon().getDiscountPercent();
+        int price = getOrderPrice() * discountPercent / 100; //쿠폰은 상품 한 개 가격에서 할인 적용
+        discount(price);
     }
 
     public void cancelCouponCard(){
@@ -75,8 +78,9 @@ public class OrderItem extends BaseTimeEntity {
         this.discountPrice = 0;
     }
 
-    public void discount(int price){
+    private void discount(int price){
         this.discountPrice += price;
+        this.totalPrice -= this.discountPrice;
     }
 
     private OrderItem(Product product, int quantity, String size, String color) {
@@ -85,8 +89,8 @@ public class OrderItem extends BaseTimeEntity {
         this.quantity = quantity;
         this.size = size;
         this.color = color;
-        this.discountPrice = 0;
-        this.orderItemByQuantity = this.orderPrice * this.quantity;
+        this.discountPrice = 0; //쿠폰으로 인한 할인가만 적용
+        this.totalPrice = this.orderPrice * this.quantity;
         product.getProductOption().decreaseStock(quantity);
     }
 }

--- a/src/main/java/project/trendpick_pro/domain/rebate/controller/AdmRebateController.java
+++ b/src/main/java/project/trendpick_pro/domain/rebate/controller/AdmRebateController.java
@@ -6,17 +6,13 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.util.StringUtils;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
+import project.trendpick_pro.domain.rebate.entity.MonthRebateData;
 import project.trendpick_pro.domain.rebate.entity.RebateOrderItem;
 import project.trendpick_pro.domain.rebate.service.RebateService;
 import project.trendpick_pro.global.util.rq.Rq;
 import project.trendpick_pro.global.util.rsData.RsData;
 import project.trendpick_pro.global.util.Ut;
-
-import java.util.Arrays;
 import java.util.List;
 
 @Controller
@@ -35,7 +31,7 @@ public class AdmRebateController {
     @PostMapping("/makeData")
     @PreAuthorize("hasAuthority({'BRAND_ADMIN'})")
     public String makeData(String yearMonth) {
-        RsData makeDateRsData = rebateService.makeData(rq.getBrandName(), yearMonth);
+        RsData makeDateRsData = rebateService.makeRebateOrderItem(rq.getBrandName(), yearMonth);
         if (makeDateRsData.isFail()) {
             return rq.historyBack("정산할 데이터가 없습니다.");
         }
@@ -48,17 +44,19 @@ public class AdmRebateController {
         if (!StringUtils.hasText(yearMonth))
             yearMonth = Ut.date.getCurrentYearMonth();
 
-        List<RebateOrderItem> items = rebateService.findRebateDataByCurrentYearMonth(rq.getBrandName(), yearMonth);
-
+        List<RebateOrderItem> items = rebateService.findRebateOrderItemByCurrentYearMonth(rq.getBrandName(), yearMonth);
+        MonthRebateData monthRebateData = rebateService.findMonthRebateData(rq.getBrandName(), yearMonth);
         model.addAttribute("yearMonth", yearMonth);
         model.addAttribute("items", items);
+        model.addAttribute("monthRebateData", monthRebateData);
+
         return "trendpick/admin/rebateOrderItemList";
     }
 
     @PostMapping("/rebateOne/{orderItemId}")
     @PreAuthorize("hasAuthority({'BRAND_ADMIN'})")
     public String rebateOne(@PathVariable long orderItemId, HttpServletRequest req) {
-        RsData result = rebateService.rebate(orderItemId);
+        RsData result = rebateService.rebate(rq.getBrandName(), orderItemId);
         if (result.isFail()) {
             return rq.historyBack(result);
         }
@@ -68,15 +66,10 @@ public class AdmRebateController {
 
     @PostMapping("/rebate")
     @PreAuthorize("hasAuthority({'BRAND_ADMIN'})")
-    public String rebate(String ids, HttpServletRequest req) {
-        String[] idsArr = ids.split(",");
-        Arrays.stream(idsArr)
-                .mapToLong(Long::parseLong)
-                .forEach(rebateService::rebate);
-        String yearMonth = Ut.url.getQueryParamValue(req.getHeader("Referer"), "yearMonth", "");
-
-        String redirect = "redirect:/trendpick/admin/rebateOrderItemList?yearMonth=" + yearMonth;
-        redirect += "&msg=" + Ut.url.encode("%d건의 정산품목을 정산처리하였습니다.".formatted(idsArr.length));
-        return redirect;
+    public String rebate(@RequestParam String yearMonth) { //전체 정산처리
+        RsData result = rebateService.rebate(rq.getBrandName(), yearMonth);
+        if(result.isFail())
+            return rq.historyBack(result);
+        return rq.redirectWithMsg("/trendpick/admin/rebateOrderItemList?yearMonth=" + yearMonth, result);
     }
 }

--- a/src/main/java/project/trendpick_pro/domain/rebate/entity/MonthRebateData.java
+++ b/src/main/java/project/trendpick_pro/domain/rebate/entity/MonthRebateData.java
@@ -1,0 +1,82 @@
+package project.trendpick_pro.domain.rebate.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.trendpick_pro.domain.common.base.BaseTimeEntity;
+import project.trendpick_pro.domain.store.entity.Store;
+import project.trendpick_pro.global.util.Ut;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class MonthRebateData extends BaseTimeEntity { //월 정산데이터
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "month_rebate_data_id")
+    private Long id;
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+    @Column(name = "'year_month'")
+    private String yearMonth; //연월
+    private LocalDateTime fromDate;
+    private LocalDateTime toDate;
+    @Column(name = "total_sales")
+    private long totalSales; //총 매출
+    @Column(name = "net_profit")
+    private long netProfit; //순이익 : 총 매출 - 수수료
+    @Column(name = "tax")
+    private long tax; //수수료
+    @Column(name = "sale_count")
+    private int saleCount;  //총판매개수
+    @Column(name = "total_discount")
+    private int totalDiscount; //총할인금액
+    @Column(name = "refund_date")
+    private LocalDateTime refundDate; //환급날짜
+    @Column(name = "refund_amount")
+    private Long refundAmount;
+
+    public MonthRebateData(Store store, String yearMonth){
+        this.store = store;
+        int monthEndDay = Ut.date.getEndDayOf(yearMonth);
+        String fromDateStr = yearMonth + "-01 00:00:00.000000";
+        String toDateStr = yearMonth + "-%02d 23:59:59.999999".formatted(monthEndDay);
+        this.yearMonth = yearMonth;
+        this.fromDate = Ut.date.parse(fromDateStr); //yyyy-MM-dd HH:mm:ss.SSSSSS 패턴으로 만들기
+        this.toDate = Ut.date.parse(toDateStr);
+        this.totalSales = 0;
+        this.netProfit = 0;
+        this.tax = 0;
+        this.saleCount = 0;
+        this.totalDiscount = 0;
+    }
+
+    public void rebate(List<RebateOrderItem> rebateOrderItems){ //총정산
+        for (RebateOrderItem rebateOrderItem : rebateOrderItems) {
+            rebate(rebateOrderItem);
+        }
+    }
+
+    public void rebate(RebateOrderItem rebateOrderItem){ //총정산
+            this.totalSales += rebateOrderItem.getTotalPrice();
+            this.netProfit += rebateOrderItem.calculateRebatePrice();
+            this.saleCount += rebateOrderItem.getQuantity();
+            this.tax += (int)(rebateOrderItem.getTotalPrice() * 0.05);
+            this.totalDiscount += rebateOrderItem.getDiscountPrice();
+    }
+
+    //캐시로 환급
+    public void refundDone(){
+        this.refundDate = LocalDateTime.now();
+        this.refundAmount = getNetProfit();
+    }
+}

--- a/src/main/java/project/trendpick_pro/domain/rebate/entity/RebateOrderItem.java
+++ b/src/main/java/project/trendpick_pro/domain/rebate/entity/RebateOrderItem.java
@@ -59,7 +59,7 @@ public class RebateOrderItem extends BaseTimeEntity {
     @Column(name = "color", nullable = false)
     private String color;
 
-    @Column(name = "count", nullable = false)
+    @Column(name = "quantity", nullable = false)
     private int quantity;
     @OneToOne(fetch = LAZY)
     @ToString.Exclude
@@ -86,37 +86,36 @@ public class RebateOrderItem extends BaseTimeEntity {
 
     public RebateOrderItem(OrderItem orderItem) {
         this.orderItem = orderItem;
-        order=orderItem.getOrder();
-        product=orderItem.getProduct();
-        couponCard=orderItem.getCouponCard();
-        orderPrice=orderItem.getOrderPrice();
-        totalPrice=orderItem.getOrderItemByQuantity();
-        discountPrice=orderItem.getDiscountPrice();
-        size=orderItem.getSize();
-        color=orderItem.getColor();
-        quantity=orderItem.getQuantity();
+        this.order=orderItem.getOrder();
+        this.product=orderItem.getProduct();
+        this.couponCard=orderItem.getCouponCard();
+        this.orderPrice=orderItem.getOrderPrice();
+        this.totalPrice=orderItem.getTotalPrice();
+        this.discountPrice=orderItem.getDiscountPrice();
+        this.size=orderItem.getSize();
+        this.color=orderItem.getColor();
+        this.quantity=orderItem.getQuantity();
         // 상품 추가 데이터
-        productSubject=orderItem.getProduct().getTitle();
+        this.productSubject=orderItem.getProduct().getTitle();
 
         // 주문 품목 추가데이터
-        orderItemCreateDate=orderItem.getOrder().getCreatedDate();
+        this.orderItemCreateDate=orderItem.getOrder().getCreatedDate();
 
         // 구매자 추가 데이터
-        buyer=orderItem.getOrder().getMember();
-        buyerName=orderItem.getOrder().getMember().getUsername();
+        this.buyer=orderItem.getOrder().getMember();
+        this.buyerName=orderItem.getOrder().getMember().getUsername();
 
         // 판매자 추가 데이터
-        seller=orderItem.getProduct().getProductOption().getBrand();
-        sellerName=orderItem.getProduct().getProductOption().getBrand().getName();
+        this.seller=orderItem.getProduct().getProductOption().getBrand();
+        this.sellerName=orderItem.getProduct().getProductOption().getBrand().getName();
     }
 
     public int calculateRebatePrice() {
-        return (totalPrice*quantity - discountPrice) - (int)(totalPrice * 0.05); // 정산금액 수수료 5%(임의) 제외하고 계산
+        return totalPrice - (int)(totalPrice * 0.05); // 정산금액 수수료 5%(임의) 제외하고 계산
     }
-    public boolean checkAlreadyRebate() {
-        if (rebateDate != null) {
+    public boolean isAlreadyRebated() {
+        if(rebateDate == null)
             return false;
-        }
         return true;
     }
 
@@ -129,23 +128,24 @@ public class RebateOrderItem extends BaseTimeEntity {
         return rebateDate != null;
     }
 
-    public void updateWith(RebateOrderItem item){
-        orderItem = item.getOrderItem();
-        order=item.getOrder();
-        product=item.getProduct();
-        couponCard=item.getCouponCard();
-        orderPrice=item.getOrderPrice();
-        totalPrice=item.getTotalPrice();
-        discountPrice=item.getDiscountPrice();
-        size=item.getSize();
-        color=item.getColor();
-        quantity=item.getQuantity();
-        productSubject=item.getProduct().getTitle();
-        orderItemCreateDate=item.getOrder().getCreatedDate();
-        buyer=item.getOrder().getMember();
-        buyerName=item.getOrder().getMember().getUsername();
-        seller=item.getProduct().getProductOption().getBrand();
-        sellerName=item.getProduct().getProductOption().getBrand().getName();
+    public RebateOrderItem updateWith(RebateOrderItem item){
+        this.orderItem = item.getOrderItem();
+        this.order=item.getOrder();
+        this.product=item.getProduct();
+        this.couponCard=item.getCouponCard();
+        this.orderPrice=item.getOrderPrice();
+        this.totalPrice=item.getTotalPrice();
+        this.discountPrice=item.getDiscountPrice();
+        this.size=item.getSize();
+        this. color=item.getColor();
+        this. quantity=item.getQuantity();
+        this.productSubject=item.getProduct().getTitle();
+        this.orderItemCreateDate=item.getOrder().getCreatedDate();
+        this.buyer=item.getOrder().getMember();
+        this.buyerName=item.getOrder().getMember().getUsername();
+        this.seller=item.getProduct().getProductOption().getBrand();
+        this.sellerName=item.getProduct().getProductOption().getBrand().getName();
+        return this;
     }
 }
 

--- a/src/main/java/project/trendpick_pro/domain/rebate/repository/MonthRebateDataRepository.java
+++ b/src/main/java/project/trendpick_pro/domain/rebate/repository/MonthRebateDataRepository.java
@@ -1,0 +1,16 @@
+package project.trendpick_pro.domain.rebate.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.security.core.parameters.P;
+import project.trendpick_pro.domain.rebate.entity.MonthRebateData;
+
+import java.util.Optional;
+
+public interface MonthRebateDataRepository extends JpaRepository<MonthRebateData, Long> {
+    @Query("select d from MonthRebateData d where d.store.brand = :storeName and d.yearMonth = :yearMonth")
+    Optional<MonthRebateData> findByStoreNameAndYearMonth(
+            @Param("storeName") String storeName, @Param("yearMonth") String yearMonth);
+
+}

--- a/src/main/java/project/trendpick_pro/domain/rebate/scheduler/RebateScheduler.java
+++ b/src/main/java/project/trendpick_pro/domain/rebate/scheduler/RebateScheduler.java
@@ -1,0 +1,64 @@
+package project.trendpick_pro.domain.rebate.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Scheduled;
+import project.trendpick_pro.domain.rebate.entity.MonthRebateData;
+import project.trendpick_pro.domain.rebate.repository.MonthRebateDataRepository;
+import project.trendpick_pro.domain.rebate.service.RebateService;
+import project.trendpick_pro.domain.store.entity.Store;
+import project.trendpick_pro.domain.store.repository.StoreRepository;
+import project.trendpick_pro.domain.store.service.StoreService;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Configuration
+public class RebateScheduler {
+    private final RebateService rebateService;
+    private final MonthRebateDataRepository monthRebateDataRepository;
+    private final StoreRepository storeRepository;
+    private final StoreService storeService;
+
+    @Scheduled(cron = "0 0 1 * * ?") //매월 1일 객체생성
+    private void createMonthRebateObject(){
+        String currentYearMonth = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM"));
+        createEmptyRebateDataForAllStore(currentYearMonth);
+    }
+
+    @Scheduled(cron = "0 0 10 * * ?") //매월 10일 (배송확정 되는데까지 시간 고려)
+    private void rebateFinish(){ //전체정산 (auto)
+        String pastYearMonth = LocalDateTime.now().minusMonths(1).format(DateTimeFormatter.ofPattern("yyyy-MM")); //지난 달
+        rebateForAllStore(pastYearMonth);
+    }
+
+
+    private void rebateForAllStore(String yearMonth) {
+        List<Store> stores = storeRepository.findAll();
+        for (Store store : stores) {
+            MonthRebateData monthRebateData = rebateProcess(yearMonth, store);
+            refund(monthRebateData);
+        }
+    }
+
+    private void refund(MonthRebateData monthRebateData) {
+        storeService.addRebateCash(monthRebateData.getStore(), monthRebateData.getNetProfit()); //캐시로 반환
+        monthRebateData.refundDone();
+    }
+
+    private MonthRebateData rebateProcess(String yearMonth, Store store) {
+        rebateService.makeRebateOrderItem(store.getBrand(), yearMonth);
+        rebateService.rebate(store.getBrand(), yearMonth);
+        return rebateService.findMonthRebateData(store.getBrand(), yearMonth);
+    }
+
+    private void createEmptyRebateDataForAllStore(String currentYearMonth) {
+        List<MonthRebateData> data = new ArrayList<>();
+        List<Store> stores = storeRepository.findAll();
+        for (Store store : stores)
+            data.add(new MonthRebateData(store, currentYearMonth));
+        monthRebateDataRepository.saveAll(data);
+    }
+}

--- a/src/main/java/project/trendpick_pro/domain/rebate/service/RebateService.java
+++ b/src/main/java/project/trendpick_pro/domain/rebate/service/RebateService.java
@@ -1,13 +1,15 @@
 package project.trendpick_pro.domain.rebate.service;
 
-import project.trendpick_pro.domain.orders.entity.OrderItem;
+import project.trendpick_pro.domain.rebate.entity.MonthRebateData;
 import project.trendpick_pro.domain.rebate.entity.RebateOrderItem;
 import project.trendpick_pro.global.util.rsData.RsData;
 
 import java.util.List;
 
 public interface RebateService {
-    RsData makeData(String brandName,String yearMonth);
-    List<RebateOrderItem> findRebateDataByCurrentYearMonth(String brandName,String yearMonth);
-    RsData rebate(Long orderItemId);
+    RsData makeRebateOrderItem(String brandName, String yearMonth);
+    List<RebateOrderItem> findRebateOrderItemByCurrentYearMonth(String brandName, String yearMonth);
+    RsData rebate(String storeName, Long orderItemId);
+    RsData rebate(String brandName, String currentYearMonth);
+    MonthRebateData findMonthRebateData(String brandName, String yearMonth);
 }

--- a/src/main/java/project/trendpick_pro/domain/store/entity/Store.java
+++ b/src/main/java/project/trendpick_pro/domain/store/entity/Store.java
@@ -26,7 +26,7 @@ public class Store extends BaseTimeEntity {
         this.brand = brand;
     }
 
-    public void addRebatedCash(int price) {
+    public void addRebatedCash(long price) {
         this.rebatedCash += price;
     }
 

--- a/src/main/java/project/trendpick_pro/domain/store/service/StoreService.java
+++ b/src/main/java/project/trendpick_pro/domain/store/service/StoreService.java
@@ -2,9 +2,13 @@ package project.trendpick_pro.domain.store.service;
 
 import project.trendpick_pro.domain.store.entity.Store;
 
+import java.util.List;
+
 public interface StoreService {
     Store save(Store store);
     Store findByBrand(String storeName);
-    void addRebateCash(String storeName, int calculateRebatePrice);
+    void addRebateCash(Store store, long price);
     int getRestCash(String storeName);
+
+    void saveAll(List<String> brands);
 }

--- a/src/main/java/project/trendpick_pro/domain/store/service/impl/StoreServiceImpl.java
+++ b/src/main/java/project/trendpick_pro/domain/store/service/impl/StoreServiceImpl.java
@@ -6,6 +6,8 @@ import org.springframework.transaction.annotation.Transactional;
 import project.trendpick_pro.domain.store.entity.Store;
 import project.trendpick_pro.domain.store.repository.StoreRepository;
 import project.trendpick_pro.domain.store.service.StoreService;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -15,7 +17,7 @@ public class StoreServiceImpl implements StoreService {
 
     @Override
     @Transactional
-    public Store save(Store store){
+    public Store save(Store store) {
         return storeRepository.save(store);
     }
 
@@ -28,13 +30,23 @@ public class StoreServiceImpl implements StoreService {
 
     @Override
     @Transactional
-    public void addRebateCash(String storeName, int calculateRebatePrice) {
-        Store store = findByBrand(storeName);
-        store.addRebatedCash(calculateRebatePrice);
+    public void addRebateCash(Store store, long price) {
+        store.addRebatedCash(price);
+        storeRepository.save(store);
     }
 
     @Override
     public int getRestCash(String storeName) {
         return findByBrand(storeName).getRebatedCash();
+    }
+
+    @Override
+    @Transactional
+    public void saveAll(List<String> names) {
+        List<Store> list = new ArrayList<>();
+        for (String name : names) {
+            list.add(new Store(name));
+        }
+        storeRepository.saveAll(list);
     }
 }

--- a/src/main/java/project/trendpick_pro/domain/withdraw/entity/WithdrawApply.java
+++ b/src/main/java/project/trendpick_pro/domain/withdraw/entity/WithdrawApply.java
@@ -25,6 +25,7 @@ public class WithdrawApply {
     private Long id;
     @ManyToOne(fetch = LAZY)
     private Member applicant;
+    private String store;
     private String bankName;
     private String bankAccountNo;
     private int price;
@@ -62,6 +63,7 @@ public class WithdrawApply {
                 .bankAccountNo(withDrawApplyForm.getBankAccountNo())
                 .price(withDrawApplyForm.getPrice())
                 .applicant(applicant)
+                .store(applicant.getBrand())
                 .build();
     }
 

--- a/src/main/java/project/trendpick_pro/global/basedata/BaseData.java
+++ b/src/main/java/project/trendpick_pro/global/basedata/BaseData.java
@@ -23,6 +23,7 @@ import project.trendpick_pro.domain.category.service.MainCategoryService;
 import project.trendpick_pro.domain.category.service.SubCategoryService;
 import project.trendpick_pro.domain.common.file.CommonFile;
 import project.trendpick_pro.domain.coupon.entity.expirationPeriod.ExpirationType;
+import project.trendpick_pro.domain.store.service.StoreService;
 import project.trendpick_pro.global.kafka.view.service.ViewService;
 import project.trendpick_pro.domain.coupon.entity.Coupon;
 import project.trendpick_pro.domain.coupon.entity.dto.request.StoreCouponSaveRequest;
@@ -97,6 +98,7 @@ public class BaseData {
             RecommendService recommendService,
             BrandService brandService,
             ProductService productService,
+            StoreService storeService,
             ViewService viewService,
             ProductRepository productRepository,
             ReviewRepository reviewRepository,
@@ -109,6 +111,8 @@ public class BaseData {
             public void run(String... args) {
 
                 tagNameServiceImpl.saveAll(tags);
+                brandService.saveAll(brands);
+                storeService.saveAll(brands);
                 memberService.joinAll(makeBrandMembers(brands));
                 mainCategoryService.saveAll(mainCategories);
 
@@ -119,10 +123,10 @@ public class BaseData {
                 accessKeyMap.put("secretKey", secretKey);
                 accessKeyMap.put("bucket", bucket);
 
-                int memberCount = 100;
-                int productCount = 2000;
-                int reviewCount = 100;
-                int couponCount = 100;
+                int memberCount = 10;
+                int productCount = 200;
+                int reviewCount = 10;
+                int couponCount = 10;
                 String brandName = "polo";
 
                 saveMembers(memberCount, tagNameServiceImpl, memberService);

--- a/src/main/resources/templates/trendpick/admin/rebateOrderItemList.html
+++ b/src/main/resources/templates/trendpick/admin/rebateOrderItemList.html
@@ -14,22 +14,34 @@
                 정산
             </h1>
 
-            <div class="mt-2">
-                <select name="yearMonth" class="select select-bordered"
-                        th:currentUrl="${@rq.modifyQueryParam('yearMonth', '')}"
-                        onchange="location.href = this.getAttribute('currentUrl') + this.value;">
-                    <option value="2023-06">2023-06</option>
-                    <option value="2023-07">2023-07</option>
-                    <option value="2023-08">2023-08</option>
-                    <option value="2023-09">2023-09</option>
-                    <option value="2023-10">2023-10</option>
-                    <option value="2023-11">2023-11</option>
-                    <option value="2023-12">2023-12</option>
-                </select>
-                <script th:inline="javascript">
-                    const yearMonth = /*[[ ${yearMonth} ]]*/ null;
-                    $('select[name=yearMonth]').last().val(yearMonth);
-                </script>
+            <div class="flex">
+                <div class="mt-2 flex flex-column">
+                    <select name="yearMonth" class="select select-bordered"
+                            th:currentUrl="${@rq.modifyQueryParam('yearMonth', '')}"
+                            onchange="location.href = this.getAttribute('currentUrl') + this.value;">
+                        <option value="2023-06">2023-06</option>
+                        <option value="2023-07">2023-07</option>
+                        <option value="2023-08">2023-08</option>
+                        <option value="2023-09">2023-09</option>
+                        <option value="2023-10">2023-10</option>
+                        <option value="2023-11">2023-11</option>
+                        <option value="2023-12">2023-12</option>
+                    </select>
+                    <script th:inline="javascript">
+                        const yearMonth = /*[[ ${yearMonth} ]]*/ null;
+                        $('select[name=yearMonth]').last().val(yearMonth);
+                    </script>
+                </div>
+                <div class="flex p-4">
+                    <div class="flex mb-2 mr-4">
+                        <div class="font-bold">월 총매출 </div>
+                        <div th:text="' : ' + ${#numbers.formatDecimal(monthRebateData.totalSales, 0, 'COMMA', 0, 'POINT')} + ' 원 '"></div>
+                    </div>
+                    <div class="flex mb-2">
+                        <div class="font-bold">월 정산금액 </div>
+                        <div th:text="' : ' + ${#numbers.formatDecimal(monthRebateData.netProfit, 0, 'COMMA', 0, 'POINT')} + ' 원 '"></div>
+                    </div>
+                </div>
             </div>
 
             <div class="overflow-x-auto mt-2">
@@ -43,8 +55,11 @@
                         <th>주문품목번호</th>
                         <th>결제날짜</th>
                         <th>상품명</th>
-                        <th>결제가격</th>
-                        <th>판매자</th>
+                        <th>객단가</th>
+                        <th>구매수량</th>
+                        <th>쿠폰할인금액</th>
+                        <th>결제금액</th>
+                        <th>정산수수료</th>
                         <th>정산금액</th>
                         <th>정산날짜</th>
                         <th>정산</th>
@@ -54,18 +69,22 @@
                     <tbody>
                     <tr th:each="item : ${items}">
                         <td>
-                            <input onchange="OrderItemCheckbox__changed();" th:if="${item.checkAlreadyRebate}"
+                            <input onchange="OrderItemCheckbox__changed();" th:unless="${item.isAlreadyRebated()}"
                                    type="checkbox" class="orderItemCheckbox checkbox" th:value="${item.orderItem.id}">
                         </td>
                         <td th:text="${item.orderItem.id}"></td>
                         <td th:text="${#temporals.format(item.createdDate, 'yy-MM-dd HH:mm')}"></td>
                         <td th:text="${item.productSubject}"></td>
-                        <td th:text="${#numbers.formatDecimal(item.orderPrice, 0, 'COMMA', 0, 'POINT')} + ' 원 '"></td>
-                        <td th:text="${item.sellerName}"></td>
+                        <td th:text="${#numbers.formatDecimal(item.totalPrice/item.quantity, 0, 'COMMA', 0, 'POINT')} + ' 원 '"></td>
+                        <td th:text="${item.quantity} + '개'"></td>
+                        <td th:text="${#numbers.formatDecimal(item.discountPrice, 0, 'COMMA', 0, 'POINT')} + ' 원 '"></td>
+                        <td th:text="${#numbers.formatDecimal(item.totalPrice, 0, 'COMMA', 0, 'POINT')} + ' 원 '"></td>
+                        <td th:text="${#numbers.formatDecimal(item.totalPrice * 0.05, 0, 'COMMA', 0, 'POINT')} + ' 원 '"></td>
                         <td th:text="${#numbers.formatDecimal(item.calculateRebatePrice(), 0, 'COMMA', 0, 'POINT')} + ' 원 '"></td>
                         <td th:text="${#temporals.format(item.rebateDate, 'yy-MM-dd HH:mm')}"></td>
                         <td>
-                            <a th:if="${item.checkAlreadyRebate}" href="javascript:;" onclick="$(this).next().submit();"
+                            <a th:if="${item.isAlreadyRebated()}">정산완료</a>
+                            <a th:unless="${item.isAlreadyRebated()}" href="javascript:;" onclick="$(this).next().submit();"
                                class="btn btn-primary btn-xs">정산</a>
                             <form method="POST" th:action="@{|/trendpick/admin/rebateOne/${item.orderItem.id}|}"
                                   hidden></form>
@@ -75,14 +94,10 @@
                 </table>
             </div>
 
-            <div class="grid grid-cols-2 mt-2 gap-2">
-                <button type="button" onclick="history.back();" class="btn btn-outline">
-                    <i class="fa-solid fa-angle-left"></i>
-                    <span class="ml-1">뒤로가기</span>
-                </button>
-                <a href="javascript:;" onclick="RebateForm__submit();" class="btn btn-outline">선택정산</a>
-                <form method="POST" name="rebateForm"  th:action="@{|/trendpick/admin/rebate|}" hidden>
-                    <input type="hidden" name="ids">
+            <div class="form-container grid grid-cols-1 mt-2 gap-1">
+                <a href="javascript:;" onclick="if (RebateForm__submit()) document.getElementById('rebateForm').submit();" class="btn btn-outline">전체정산처리</a>
+                <form id="rebateForm" th:action="@{|/trendpick/admin/rebate|}" method="post" hidden>
+                    <input type="hidden" name="yearMonth" th:value="${yearMonth}">
                 </form>
             </div>
 
@@ -108,34 +123,14 @@
                 function RebateForm__submit() {
                     if (RebateForm__submitDone) return;
 
-                    const form = document.rebateForm;
-
-                    const $checked = $('.orderItemCheckbox:checked');
-
-                    if ($checked.length == 0) {
-                        alert('정산할 주문품목을 선택해주세요.');
-                        return;
-                    }
-
-                    var confirmAction = confirm("선택 상품들을 정산하시겠습니까?" +
-                        "\n(한 번 정산하면 취소할 수 없습니다.)");
+                    var confirmAction = confirm("정산처리 하시겠습니까?" +
+                        "\n(명월 10일에 자동 정산처리됩니다.)");
                     if (confirmAction) {
-                        // 폼 전송
-                        //return true;
-                        const ids = $checked.map((index, el) => $(el).val()).get();
-                        form.ids.value = ids;
-                        form.submit();
-                        RebateForm__submitDone = true;
                         return true;
                     } else {
-                        // 폼 전송 후 페이지 이동 취소
-                        setTimeout(function () {
-                            window.stop();
-                        }, 0);
                         return false;
                     }
                 }
-
             </script>
         </div>
     </section>

--- a/src/main/resources/templates/trendpick/admin/sales.html
+++ b/src/main/resources/templates/trendpick/admin/sales.html
@@ -10,7 +10,7 @@
     <h1 class="text-center text-5xl font-bold mb-6">판매내역</h1>
 
     <div class="text-black p-2 rounded-lg font-bold text-right" style="font-size: 2em;">
-        <span th:text="${#dates.format(#dates.createNow(), 'MM')+'월 정산금: '+ #numbers.formatDecimal(totalPricePerMonth, 0, 'COMMA', 0, 'POINT')}+'원'"></span>
+        <span th:text="${#dates.format(#dates.createNow(), 'MM')+'월 매출현황: '+ #numbers.formatDecimal(totalPricePerMonth, 0, 'COMMA', 0, 'POINT')}+'원'"></span>
     </div>
 
     <table class="table">

--- a/src/main/resources/templates/trendpick/orders/order-form.html
+++ b/src/main/resources/templates/trendpick/orders/order-form.html
@@ -109,7 +109,7 @@
                     <span class="text-center" th:text="${orderItem.quantity}"></span>
                 </td>
                 <td class="text-center font-bold">
-                    <span th:text="${#numbers.formatDecimal(orderItem.getOrderItemByQuantity, 0, 'COMMA', 0, 'POINT')}" th:value="${order.getTotalPrice}"></span> 원
+                    <span th:text="${#numbers.formatDecimal(orderItem.getTotalPrice, 0, 'COMMA', 0, 'POINT')}" th:value="${order.getTotalPrice}"></span> 원
                 </td>
                 <td class="text-center font-bold">
                     <form th:if="${orderItem.discountPrice} == 0" class="card-actions justify-center" id="couponForm">


### PR DESCRIPTION
## 개편 내용
- 월 정산 데이터 (MonthRebateData) 도입 
  - RebateOrderItem의 데이터를 모아서 월 통계 데이터를 저장
  - Store와 ManyToOne 매핑
  - 매월 1일 모든 Store에 대해 자동으로 객체 생성

- 정산 프로세스 정리
  - 주문 완료 및 배송 완료 (구매 결정 완료) 시 선 정산 가능 (캐시로 변환 처리는 X) -> 월 매출 통계를 누적 시키기 위함
  - 다음 달 10일에 자동으로 정산 마무리 작업 (정산 되지 않은 데이터를 찾아서 정산) -> Store 캐시로 변환 처리

---
## 리팩토링 내용
- 변수명 수정
- SRP 적용
- 체크 박스 선택 정산 -> 전체 정산
  - 체크 박스로 선택해서 정산하는 기능이 제대로 작동하지 않았고, 단일 정산과 차이점이 없다고 느껴졌습니다.
  - 전체 정산으로 대체하여 생성되어 있는 정산 데이터 중 정산 가능한 (구매 결정 완료) 정산 데이터를 정산 처리하도록 했습니다.

close #439 
close #438 

궁금하거나 피드백 있으시면 편하게 말씀 부탁 드릴게요 !